### PR TITLE
add package repositories docs from snapcraft

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,28 @@
+@import url('https://fonts.googleapis.com/css2?family=Ubuntu:ital@0;1&display=swap');
+
+body {
+    font-family: Ubuntu, "times new roman", times, roman, serif;
+}
+
+div .toctree-wrapper {
+    column-count: 2;
+}
+
+div .toctree-wrapper>ul {
+    margin: 0;
+}
+
+ul .toctree-l1 {
+    margin: 0;
+    -webkit-column-break-inside: avoid;
+    page-break-inside: avoid;
+    break-inside: avoid-column;
+}
+
+.wy-nav-content {
+    max-width: none;
+}
+
+.log-snippets {
+    color: rgb(141, 141, 141);
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,9 @@ show_authors = False
 
 html_theme = "furo"
 html_static_path = ["_static"]
+html_css_files = [
+    "css/custom.css",
+]
 
 # endregion
 # region Options for extensions

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -1,7 +1,7 @@
 .. _explanation:
 
 Explanation
-*********
+***********
 
 .. toctree::
    :maxdepth: 1

--- a/docs/howto/add_repo.rst
+++ b/docs/howto/add_repo.rst
@@ -1,0 +1,38 @@
+Add a Package Repository
+************************
+
+It's possible to add your own apt repositories as sources for build-packages and
+stage-packages, including those hosted on a PPA, the Personal Package Archive,
+which serves personally hosted non-standard packages.
+
+Third-party apt repositories can be added to a Craft-based project by using
+the top-level ``package-repositories`` keyword with either a PPA-type
+repository, or a deb-type repository:
+
+PPA-type repository:
+
+.. code-block:: yaml
+
+   package-repositories:
+    - type: apt
+      ppa: snappy-dev/snapcraft-daily
+
+deb-type repository:
+
+.. code-block:: yaml
+
+   package-repositories:
+     - type: apt
+       components: [main]
+       suites: [xenial]
+       key-id: 78E1918602959B9C59103100F1831DDAFC42E99D
+       url: http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu
+
+As shown above, PPA-type repositories and traditional deb-type each require a
+different set of properties.
+
+* :ref:`PPA-type properties <ppa-properties>`
+* :ref:`deb-type properties <deb-properties>`
+
+Once configured, packages provided by these repositories will become available
+via stage-packages and build-packages.

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -5,3 +5,5 @@ How-to guides
 
 .. toctree::
    :maxdepth: 1
+
+   add_repo

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -6,6 +6,8 @@ Reference
 .. toctree::
    :maxdepth: 1
 
+   repo_properties
+
 Indices and tables
 ==================
 

--- a/docs/reference/repo_properties.rst
+++ b/docs/reference/repo_properties.rst
@@ -1,0 +1,162 @@
+
+Package Repository Properties
+*****************************
+
+.. _ppa-properties:
+PPA properties
+==============
+
+The following properties are supported for PPA-type repositories:
+
+- type
+   - Type: enum[string]
+   - Description: Specifies type of package-repository, must currently be
+     ``apt``
+   - Examples: ``type: apt``
+- ppa
+   - Type: string
+   - Description: PPA shortcut string
+   - Format: <ppa-owner>/<ppa-name>
+   - Examples:
+      - ``ppa: snappy-devs/snapcraft-daily``
+      - ``ppa: mozillateam/firefox-next``
+
+
+.. _deb-properties:
+Deb properties
+==============
+
+The following properties are supported for Deb-type repositories:
+
+- architectures
+   - Type: list[string]
+   - Description: Architectures to enable, or restrict to, for this repository
+   - Default: If unspecified, architectures is assumed to match the host’s
+     architecture
+   - Examples:
+      - ``architectures: [i386]``
+      - ``architectures: [i386, amd64]``
+- components
+   - Type: list[string]
+   - Description: Apt repository components to enable: e.g.
+     ``main``, ``multiverse``, ``unstable``
+   - Examples:
+       - ``components: [main]``
+       - ``components: [main, multiverse, universe, restricted]``
+- formats
+   - Type: list[string]
+   - Description: List of deb types to enable
+   - Default: If unspecified, format is assumed to be ``deb``, i.e. ``[deb]``
+   - Examples:
+       - ``formats: [deb]``
+       - ``formats: [deb, deb-src]``
+- key-id
+   - Type: string
+   - Description: 40 character GPG key identifier ("long-form thumbprint" or
+     "fingerprint")
+     If not using a key-server, Snapcraft will look for the corresponding key
+     at: ``<project>/snap/keys/<key-id[-8:]>.asc``. To determine a key-id from a
+     given key file with gpg, type the following:
+     ``gpg --import-options show-only --import <file>``
+   - Format: alphanumeric, dash ``-`` , and underscores ``_`` permitted.
+   - Examples:
+       - ``key-id: 590CA3D8E4826565BE3200526A634116E00F4C82``
+
+         Snapcraft will install a corresponding key at
+         ``<project>/snap/keys/E00F4C82.asc``
+- key-server
+   - Type: string
+   - Description: Key server to fetch key ``<key-id>`` from
+   - Default: If unspecified, Snapcraft will attempt to fetch a specified key
+     from keyserver.ubuntu.com
+   - Format: Key server URL supported by ``gpg --keyserver``
+   - Examples:
+       - ``key-server: keyserver.ubuntu.com``
+       - ``key-server: hkp://keyserver.ubuntu.com:80``
+- path
+   - Type: string
+   - Description: Absolute path to repository (from ``url``). Cannot be used
+     with ``suites`` and ``components``
+   - Format: Path starting with ``/``
+   - Examples:
+       - ``path: /``
+       - ``path: /my-repo``
+- suites
+   - Type: string
+   - Description: Repository suites to enable
+   - Notes: If your deb URL does not look like it has a suite defined, it is
+     likely that the repository uses an absolute URL. Consider using ``path``
+   - Examples:
+       - ``suites: [xenial]``
+       - ``suites: [xenial, xenial-updates]``
+- type
+   - Type: enum[string]
+   - Description: Specifies type of package-repository
+   - Notes: Must be ``apt``
+   - Examples:
+       - ``type: apt``
+- url
+   - Type: string
+   - Description: Repository URL.
+   - Examples:
+       - ``url: http://archive.canonical.com/ubuntu``
+       - ``url: https://apt-repo.com/stuff``
+
+Examples
+========
+
+PPA repository using "ppa" property
+-----------------------------------
+
+.. code-block:: yaml
+
+   package-repositories:
+     - type: apt
+       ppa: snappy-dev/snapcraft-daily
+
+Typical apt repository with components and suites
+-------------------------------------------------
+
+.. code-block:: yaml
+
+   package-repositories:
+     - type: apt
+       components: [main]
+       suites: [xenial]
+       key-id: 78E1918602959B9C59103100F1831DDAFC42E99D
+       url: http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu
+
+Apt repository enabling deb sources
+-----------------------------------
+
+.. code-block:: yaml
+
+   package-repositories:
+     - type: apt
+       formats: [deb, deb-src]
+       components: [main]
+       suites: [xenial]
+       key-id: 78E1918602959B9C59103100F1831DDAFC42E99D
+       url: http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu
+
+Absolute path repository with implied root path "/"
+---------------------------------------------------
+
+.. code-block:: yaml
+
+   package-repositories:
+     - type: apt
+       key-id: AE09FE4BBD223A84B2CCFCE3F60F4B3D7FA2AF80
+       url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64
+
+Absolute path repository with explicit path and formats
+-------------------------------------------------------
+
+.. code-block:: yaml
+
+   package-repositories:
+     - type: apt
+       formats: [deb]
+       path: /
+       key-id: AE09FE4BBD223A84B2CCFCE3F60F4B3D7FA2AF80
+       url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,14 @@ types = [  # Dependencies for typing. Both types packages and mypy itself.
     "mypy[reports]>=0.991",
 ]
 docs = [
+    "furo==2022.12.07",
     "sphinx==5.3.0",
+    "sphinx-autobuild==2021.3.14",
     "sphinx-copybutton==0.5.1",
     "sphinx-design==0.3.0",
     "sphinx-pydantic==0.1.1",
     "sphinx-toolbox==3.4.0",
     "sphinx-lint==0.6.7",
-    "furo==2022.12.07",
 ]
 
 [build-system]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 env_list =  # Environments to run when called with no parameters.
-    lint-{black,ruff,pyright,shellcheck,codespell}
+    lint-{black,ruff,pyright,shellcheck,codespell,docs}
     test-py38
 minversion = 4.3.5
 # Tox will use these requirements to bootstrap a venv if necessary.
@@ -123,8 +123,8 @@ commands_pre = bash -c 'if [[ ! -e docs ]];then echo "No docs directory. Run `to
 commands = sphinx-build {posargs:-b html} {tox_root}/docs {tox_root}/docs/_build
 
 # Commented out so CI passes until we get documentation.
-;[testenv:lint-docs]
-;description = Lint the documentation with sphinx-lint
-;base = docs
-;commands = sphinx-lint --ignore docs/_build --max-line-length 80 -e all {posargs} docs/
-;labels = lint
+[testenv:lint-docs]
+description = Lint the documentation with sphinx-lint
+base = docs
+commands = sphinx-lint --ignore docs/_build --max-line-length 80 -e all {posargs} docs/
+labels = lint

--- a/tox.ini
+++ b/tox.ini
@@ -122,6 +122,11 @@ allowlist_externals = bash
 commands_pre = bash -c 'if [[ ! -e docs ]];then echo "No docs directory. Run `tox run -e sphinx-quickstart` to create one.;";return 1;fi'
 commands = sphinx-build {posargs:-b html} {tox_root}/docs {tox_root}/docs/_build
 
+[testenv:rundocs]
+description = Build documentation with an autoupdating server
+base = docs
+commands = sphinx-autobuild {posargs:-b html --open-browser --port 8080} --watch {tox_root}/craft_archives {tox_root}/docs {tox_root}/docs/_build
+
 # Commented out so CI passes until we get documentation.
 [testenv:lint-docs]
 description = Lint the documentation with sphinx-lint


### PR DESCRIPTION
This PR adds the Package Repositories docs [from snapcraft](https://snapcraft.io/docs/package-repositories) in Diátaxis format. I started experimenting with documenting the properties in the pydantic models but I wasn't 100% happy with the end result (too noisy for both dev and end-user), so this just adds the docs as regular rst/sphinx.

Also did some drive-by changes:
- Add some CSS from rockcraft to use Ubuntu font;
- Un-comment sphinx-lint and add it as a regular linter;
- Add a `rundocs` target that uses `sphinx-autobuild` to set up a server to update the docs on-the-fly.

CRAFT-1551