### PR TITLE
create v0.0.2 release

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: "pip"
           check-latest: true
       - name: Build packages
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "craft-archives"
-version = "0.0.1"
+version = "0.0.2"
 readme = "README.rst"
 dependencies = [
     "gnupg",


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

The removal of the pip cache allows the release publish to succeed. See: https://github.com/lengau/craft-archives/actions/runs/4472976635 (Note: this run is still failing because my personal repo doesn't have the appropriate pypi secret.)