### PR TITLE
repo: create the keyrings dir if necessary

### DIFF
--- a/tests/integration/repo/test_apt_key_manager.py
+++ b/tests/integration/repo/test_apt_key_manager.py
@@ -69,3 +69,19 @@ def test_install_key_from_keyserver(apt_gpg, tmp_path):
 
     assert expected_file.is_file()
     assert apt_gpg.is_key_installed(key_id="FC42E99D", keyring_path=tmp_path)
+
+
+def test_install_key_missing_directory(key_assets, tmp_path, test_keys_dir):
+    keyrings_path = tmp_path / "keyrings"
+    assert not keyrings_path.exists()
+
+    apt_gpg = AptKeyManager(
+        keyrings_path=keyrings_path,
+        key_assets=key_assets,
+    )
+
+    keypath = test_keys_dir / "FC42E99D.asc"
+    apt_gpg.install_key(key=keypath.read_text())
+
+    assert keyrings_path.exists()
+    assert keyrings_path.stat().st_mode == 0o40755

--- a/tests/unit/repo/test_apt_key_manager.py
+++ b/tests/unit/repo/test_apt_key_manager.py
@@ -237,6 +237,20 @@ def test_install_key(
     ]
 
 
+def test_install_key_missing_dir(mock_run, mock_chmod, tmp_path, key_assets):
+    keyrings_path = tmp_path / "keyrings"
+    assert not keyrings_path.exists()
+
+    apt_gpg = AptKeyManager(
+        keyrings_path=keyrings_path,
+        key_assets=key_assets,
+    )
+    mock_run.return_value.stdout = SAMPLE_GPG_SHOW_KEY_OUTPUT
+
+    apt_gpg.install_key(key=SAMPLE_KEY)
+    assert keyrings_path.exists()
+
+
 def test_install_key_with_gpg_failure(apt_gpg, mock_run):
     mock_run.side_effect = [
         subprocess.CompletedProcess(


### PR DESCRIPTION
/etc/apt/keyrings is only created by Apt after a certain version; for ubuntu 18.04, the directory is not there by default, so check and create it if necessary.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
