### PR TITLE
apt: enable uca repositories

### DIFF
--- a/craft_archives/repo/apt_key_manager.py
+++ b/craft_archives/repo/apt_key_manager.py
@@ -241,6 +241,8 @@ class AptKeyManager:
         key_server = DEFAULT_APT_KEYSERVER
         if isinstance(package_repo, package_repository.PackageRepositoryAptPPA):
             key_id = apt_ppa.get_launchpad_ppa_key_id(ppa=package_repo.ppa)
+        elif isinstance(package_repo, package_repository.PackageRepositoryAptUCA):
+            key_id = package_repository.UCA_KEY_ID
         elif isinstance(package_repo, package_repository.PackageRepositoryApt):
             key_id = package_repo.key_id
             if package_repo.key_server:

--- a/craft_archives/repo/apt_sources_manager.py
+++ b/craft_archives/repo/apt_sources_manager.py
@@ -26,7 +26,7 @@ from typing import List, Optional
 
 from craft_archives import os_release, utils
 
-from . import apt_key_manager, apt_ppa, errors, package_repository
+from . import apt_key_manager, apt_ppa, apt_uca, errors, package_repository
 
 logger = logging.getLogger(__name__)
 
@@ -216,6 +216,38 @@ class AptSourcesManager:
             keyring_path=keyring_path,
         )
 
+    def _install_sources_uca(
+        self, *, package_repo: package_repository.PackageRepositoryAptUCA
+    ) -> bool:
+        """Install UCA formatted repository.
+
+        Create a sources list config by:
+        - Looking up the codename of the host OS and using it as the "suites"
+          entry.
+        - Formulate deb URL to point to UCA.
+        - Enable only "deb" formats.
+
+        :returns: True if source configuration was changed.
+        """
+        cloud = package_repo.cloud
+        pocket = package_repo.pocket
+
+        codename = os_release.OsRelease().version_codename()
+        apt_uca.check_release_compatibility(codename, cloud, pocket)
+
+        key_id = package_repository.UCA_KEY_ID
+        keyring_path = apt_key_manager.get_keyring_path(
+            key_id, base_path=self._keyrings_dir
+        )
+        return self._install_sources(
+            components=["main"],
+            formats=["deb"],
+            name=f"cloud-{cloud}",
+            suites=[f"{codename}-{pocket}/{cloud}"],
+            url=package_repository.UCA_ARCHIVE,
+            keyring_path=keyring_path,
+        )
+
     def install_package_repository_sources(
         self,
         *,
@@ -230,6 +262,9 @@ class AptSourcesManager:
         logger.debug(f"Processing repo: {package_repo!r}")
         if isinstance(package_repo, package_repository.PackageRepositoryAptPPA):
             return self._install_sources_ppa(package_repo=package_repo)
+
+        if isinstance(package_repo, package_repository.PackageRepositoryAptUCA):
+            return self._install_sources_uca(package_repo=package_repo)
 
         if isinstance(package_repo, package_repository.PackageRepositoryApt):
             changed = self._install_sources_apt(package_repo=package_repo)

--- a/craft_archives/repo/apt_uca.py
+++ b/craft_archives/repo/apt_uca.py
@@ -1,0 +1,47 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Ubuntu Cloud Archive helpers."""
+
+import http
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from . import errors
+from .package_repository import (
+    UCA_ARCHIVE,
+    UCA_DEFAULT_POCKET,
+)
+
+
+def check_release_compatibility(
+    codename: str, cloud: str, pocket: str = UCA_DEFAULT_POCKET
+) -> None:
+    """Raise an exception if the release is incompatible with codename."""
+    request = UCA_ARCHIVE + f"/dists/{codename}-{pocket}/{cloud}/"
+    try:
+        urllib.request.urlopen(request)
+    except urllib.error.HTTPError as e:
+        if e.code == http.HTTPStatus.NOT_FOUND:
+            raise errors.AptUCAInstallError(
+                cloud, pocket, f"not a valid release for {codename!r}"
+            )
+        raise errors.AptUCAInstallError(
+            cloud,
+            pocket,
+            f"unexpected status code {e.code}: {e.reason!r} while fetching release",
+        )

--- a/craft_archives/repo/errors.py
+++ b/craft_archives/repo/errors.py
@@ -69,6 +69,16 @@ class AptPPAInstallError(PackageRepositoryError):
         )
 
 
+class AptUCAInstallError(PackageRepositoryError):
+    """Installation of an UCA repository failed."""
+
+    def __init__(self, cloud: str, pocket: str, reason: str) -> None:
+        super().__init__(
+            f"Failed to install UCA '{cloud}/{pocket}': {reason}",
+            resolution="Verify UCA is correct and try again",
+        )
+
+
 class AptGPGKeyringError(PackageRepositoryError):
     """GPG keyring for repository does not exist or not valid."""
 

--- a/craft_archives/repo/installer.py
+++ b/craft_archives/repo/installer.py
@@ -27,6 +27,7 @@ from .package_repository import (
     PackageRepository,
     PackageRepositoryApt,
     PackageRepositoryAptPPA,
+    PackageRepositoryAptUCA,
 )
 
 
@@ -55,7 +56,14 @@ def install(
             package_repo=package_repo
         )
         if (
-            isinstance(package_repo, (PackageRepositoryApt, PackageRepositoryAptPPA))
+            isinstance(
+                package_repo,
+                (
+                    PackageRepositoryApt,
+                    PackageRepositoryAptPPA,
+                    PackageRepositoryAptUCA,
+                ),
+            )
             and package_repo.priority is not None
         ):
             refresh_required |= preferences_manager.add(
@@ -96,6 +104,8 @@ def _unmarshal_repositories(
 
         if "ppa" in data:
             pkg_repo = PackageRepositoryAptPPA.unmarshal(data)
+        elif "cloud" in data:
+            pkg_repo = PackageRepositoryAptUCA.unmarshal(data)
         else:
             pkg_repo = PackageRepositoryApt.unmarshal(data)
 

--- a/craft_archives/repo/package_repository.py
+++ b/craft_archives/repo/package_repository.py
@@ -27,6 +27,12 @@ from overrides import overrides  # pyright: reportUnknownVariableType=false
 
 from . import errors
 
+UCA_ARCHIVE = "http://ubuntu-cloud.archive.canonical.com/ubuntu"
+UCA_NETLOC = urlparse(UCA_ARCHIVE).netloc
+UCA_VALID_POCKETS = ["updates", "proposed"]
+UCA_DEFAULT_POCKET = UCA_VALID_POCKETS[0]
+UCA_KEY_ID = "391A9AA2147192839E9DB0315EDB1B62EC4926EA"
+
 
 class PriorityString(enum.IntEnum):
     """Convenience values that represent common deb priorities."""
@@ -213,6 +219,154 @@ class PackageRepositoryAptPPA(PackageRepository):
         """The pin string for this repository if needed."""
         ppa_origin = self.ppa.replace("/", "-")
         return f"release o=LP-PPA-{ppa_origin}"
+
+
+class PackageRepositoryAptUCA(PackageRepository):
+    """A cloud package repository."""
+
+    def __init__(
+        self,
+        *,
+        cloud: str,
+        pocket: str = UCA_DEFAULT_POCKET,
+        priority: Optional[int] = None,
+    ) -> None:
+        self.type = "apt"
+        self.cloud = cloud
+        self.pocket = pocket
+        self.priority = priority
+
+        self.validate()
+
+    @overrides
+    def marshal(self) -> Dict[str, Union[str, int]]:
+        """Return the package repository data as a dictionary."""
+        data: Dict[str, Union[str, int]] = {
+            "type": "apt",
+            "cloud": self.cloud,
+            "pocket": self.pocket,
+        }
+        if self.priority is not None:
+            data["priority"] = self.priority
+        return data
+
+    def validate(self) -> None:
+        """Ensure the current repository data is valid."""
+        if not self.cloud:
+            raise errors.PackageRepositoryValidationError(
+                url=self.cloud,
+                brief="invalid cloud.",
+                details="clouds must be non-empty strings.",
+                resolution=(
+                    "Verify repository configuration and ensure that "
+                    "'cloud' is correctly specified."
+                ),
+            )
+        if self.priority == 0:
+            raise errors.PackageRepositoryValidationError(
+                url=self.cloud,
+                brief=f"invalid priority {self.priority}.",
+                details=("Priority cannot be zero."),
+                resolution="Verify priority value.",
+            )
+
+    @classmethod
+    @overrides
+    def unmarshal(cls, data: Mapping[str, str]) -> "PackageRepositoryAptUCA":
+        """Create a package repository object from the given data."""
+        if not isinstance(data, dict):
+            raise errors.PackageRepositoryValidationError(
+                url=str(data),
+                brief="invalid object.",
+                details="Package repository must be a valid dictionary object.",
+                resolution=(
+                    "Verify repository configuration and ensure that the correct "
+                    "syntax is used."
+                ),
+            )
+
+        data_copy = deepcopy(data)
+
+        cloud = data_copy.pop("cloud", "")
+        pocket = data_copy.pop("pocket", UCA_DEFAULT_POCKET)
+        repo_type = data_copy.pop("type", None)
+        priority = data_copy.pop("priority", None)
+
+        if repo_type != "apt":
+            raise errors.PackageRepositoryValidationError(
+                url=cloud,
+                brief=f"unsupported type {repo_type!r}.",
+                details="The only currently supported type is 'apt'.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'type' "
+                    "is correctly specified."
+                ),
+            )
+
+        if not isinstance(cloud, str):
+            raise errors.PackageRepositoryValidationError(
+                url=cloud,
+                brief="Invalid cloud {cloud!r}",
+                details="cloud is not a valid cloud archive.",
+                resolution=(
+                    "Verify repository configuration and ensure that 'cloud' "
+                    "is a valid cloud archive."
+                ),
+            )
+
+        if pocket not in UCA_VALID_POCKETS:
+            raise errors.PackageRepositoryValidationError(
+                url=cloud,
+                brief=f"Invalid pocket {pocket!r}.",
+                details=f"pocket must be a valid string and comprised in {UCA_VALID_POCKETS!r}",
+                resolution=(
+                    "Verify repository configuration and ensure that 'pocket' "
+                    "is correctly specified."
+                ),
+            )
+
+        if isinstance(priority, str):
+            priority = priority.upper()
+            if priority in PriorityString.__members__:
+                priority = PriorityString[priority]
+            else:
+                raise errors.PackageRepositoryValidationError(
+                    url=str(cloud),
+                    brief=f"invalid priority {priority!r}.",
+                    details=(
+                        "Priority must be 'always', 'prefer', 'defer' or a nonzero integer."
+                    ),
+                    resolution="Verify priority value.",
+                )
+        elif priority is not None:
+            try:
+                priority = int(priority)
+            except TypeError:
+                raise errors.PackageRepositoryValidationError(
+                    url=cloud,
+                    brief=f"invalid priority {priority!r}.",
+                    details=(
+                        "Priority must be 'always', 'prefer', 'defer' or a nonzero integer."
+                    ),
+                    resolution="Verify priority value.",
+                )
+
+        if data_copy:
+            keys = ", ".join([repr(k) for k in data_copy.keys()])
+            raise errors.PackageRepositoryValidationError(
+                url=cloud,
+                brief=f"unsupported properties {keys}.",
+                resolution=(
+                    "Verify repository configuration and ensure that it is correct."
+                ),
+            )
+
+        return cls(cloud=cloud, pocket=pocket, priority=priority)
+
+    @property
+    def pin(self) -> str:
+        """The pin string for this repository if needed."""
+        return f'origin "{UCA_NETLOC}"'
 
 
 class PackageRepositoryApt(PackageRepository):

--- a/craft_archives/repo/projects.py
+++ b/craft_archives/repo/projects.py
@@ -62,6 +62,7 @@ class Apt(abc.ABC, ProjectModel):
     # URL and PPA must be defined before priority so the validator can use their values
     url: Optional[str]
     ppa: Optional[str]
+    cloud: Optional[str]
     priority: Optional[PriorityValue]
 
     @classmethod
@@ -69,6 +70,8 @@ class Apt(abc.ABC, ProjectModel):
         """Create an Apt subclass object from a dictionary."""
         if "ppa" in data:
             return AptPPA.unmarshal(data)
+        if "cloud" in data:
+            return AptUCA.unmarshal(data)
         return AptDeb.unmarshal(data)
 
     @validator("priority")
@@ -78,7 +81,7 @@ class Apt(abc.ABC, ProjectModel):
         """Priority cannot be zero per apt Preferences specification."""
         if priority == 0:
             raise errors.PackageRepositoryValidationError(
-                url=str(values.get("url") or values.get("ppa")),
+                url=str(values.get("url") or values.get("ppa") or values.get("cloud")),
                 brief=f"invalid priority {priority}.",
                 details="Priority cannot be zero.",
                 resolution="Verify priority value.",
@@ -115,6 +118,18 @@ class AptPPA(Apt):
         return cls(**data)
 
 
+class AptUCA(Apt):
+    """Ubuntu Cloud Archive repository definition."""
+
+    cloud: str
+    pocket: Optional[str]
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "AptUCA":
+        """Create an AptUCA object from dictionary data."""
+        return cls(**data)
+
+
 def validate_repository(data: Dict[str, Any]) -> None:
     """Validate a package repository.
 
@@ -122,9 +137,11 @@ def validate_repository(data: Dict[str, Any]) -> None:
     """
     if not isinstance(data, dict):  # pyright: reportUnnecessaryIsInstance=false
         raise TypeError("value must be a dictionary")
-
     try:
-        AptPPA(**data)
+        if "ppa" in data:
+            AptPPA(**data)
+        elif "cloud" in data:
+            AptUCA(**data)
         return
     except pydantic.ValidationError:
         pass

--- a/craft_archives/repo/projects.py
+++ b/craft_archives/repo/projects.py
@@ -140,9 +140,10 @@ def validate_repository(data: Dict[str, Any]) -> None:
     try:
         if "ppa" in data:
             AptPPA(**data)
-        elif "cloud" in data:
+            return
+        if "cloud" in data:
             AptUCA(**data)
-        return
+            return
     except pydantic.ValidationError:
         pass
 

--- a/docs/howto/add_repo.rst
+++ b/docs/howto/add_repo.rst
@@ -3,12 +3,13 @@ Add a Package Repository
 
 It's possible to add your own apt repositories as sources for build-packages and
 stage-packages, including those hosted on a PPA, the Personal Package Archive,
-which serves personally hosted non-standard packages.
+which serves personally hosted non-standard packages, and those hosted on the
+UCA, the Ubuntu Cloud Archive.
 
 Third-party repositories can be added to the project file of a Craft Application
 (like Snapcraft, Rockcraft, or Charmcraft) by using the top-level
-``package-repositories`` keyword with either a PPA-type repository, or a
-deb-type repository:
+``package-repositories`` keyword with either a PPA-type repository, an UCA-type
+repository or a deb-type repository:
 
 PPA-type repository:
 
@@ -17,6 +18,15 @@ PPA-type repository:
    package-repositories:
     - type: apt
       ppa: snappy-dev/snapcraft-daily
+
+UCA-type repository:
+
+.. code-block:: yaml
+
+   package-repositories:
+    - type: apt
+      cloud: antelope
+      pocket: updates
 
 deb-type repository:
 
@@ -29,10 +39,11 @@ deb-type repository:
        key-id: 78E1918602959B9C59103100F1831DDAFC42E99D
        url: http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu
 
-As shown above, PPA-type repositories and traditional deb-type each require a
-different set of properties.
+As shown above, PPA-type repositories, UCA-type repositories and traditional
+deb-type each require a different set of properties.
 
 * :ref:`PPA-type properties <ppa-properties>`
+* :ref:`UCA-type properties <uca-properties>`
 * :ref:`deb-type properties <deb-properties>`
 
 Once configured, packages provided by these repositories will become available

--- a/docs/reference/repo_properties.rst
+++ b/docs/reference/repo_properties.rst
@@ -22,6 +22,30 @@ The following properties are supported for PPA-type repositories:
       - ``ppa: snappy-devs/snapcraft-daily``
       - ``ppa: mozillateam/firefox-next``
 
+.. _uca-properties:
+
+The following properties are supported for UCA-type repositories:
+
+- type
+   - Type: enum[string]
+   - Description: Specifies type of package-repository, must currently be
+     ``apt``
+   - Examples: ``type: apt``
+- cloud
+   - Type: string
+   - Description: UCA release name
+   - Format: <uca-release>
+   - Examples:
+      - ``cloud: antelope``
+      - ``cloud: zed``
+- pocket
+   - Type: enum[string]
+   - Description: Pocket to get packages from, must be either ``updates``
+     or ``proposed``
+   - Default: If unspecified, pocket is assumed to be ``updates``
+   - Examples:
+      - ``pocket: updates``
+      - ``pocket: proposed``
 
 .. _deb-properties:
 
@@ -115,6 +139,23 @@ PPA repository using "ppa" property
    package-repositories:
      - type: apt
        ppa: snappy-dev/snapcraft-daily
+
+UCA repository using "cloud" property
+-------------------------------------
+
+.. code-block:: yaml
+   package-repositories:
+     - type: apt
+       cloud: antelope
+
+UCA repository using "pocket" property
+--------------------------------------
+
+.. code-block:: yaml
+   package-repositories:
+     - type: apt
+       cloud: antelope
+       pocket: updates
 
 Typical apt repository with components and suites
 -------------------------------------------------

--- a/tests/unit/repo/test_apt_key_manager.py
+++ b/tests/unit/repo/test_apt_key_manager.py
@@ -20,11 +20,12 @@ from unittest import mock
 from unittest.mock import call
 
 import pytest
-from craft_archives.repo import apt_ppa, errors
+from craft_archives.repo import apt_ppa, errors, package_repository
 from craft_archives.repo.apt_key_manager import AptKeyManager
 from craft_archives.repo.package_repository import (
     PackageRepositoryApt,
     PackageRepositoryAptPPA,
+    PackageRepositoryAptUCA,
 )
 
 with open(pathlib.Path(__file__).parent / "test_data/FC42E99D.asc") as _f:
@@ -60,6 +61,11 @@ def mock_apt_ppa_get_signing_key(mocker):
         spec=apt_ppa.get_launchpad_ppa_key_id,
         return_value="FAKE-PPA-SIGNING-KEY",
     )
+
+
+@pytest.fixture(autouse=True)
+def mock_apt_uca_key_id(mocker):
+    yield mocker.patch.object(package_repository, "UCA_KEY_ID", "FAKE-UCA-KEY-ID")
 
 
 @pytest.fixture()
@@ -429,4 +435,22 @@ def test_install_package_repository_key_ppa_from_keyserver(apt_gpg, mocker):
     assert updated is True
     assert mock_install_key_from_keyserver.mock_calls == [
         call(key_id="FAKE-PPA-SIGNING-KEY", key_server="keyserver.ubuntu.com")
+    ]
+
+
+def test_install_package_repository_key_uca_from_keyserver(apt_gpg, mocker):
+    mock_install_key_from_keyserver = mocker.patch(
+        "craft_archives.repo.apt_key_manager.AptKeyManager.install_key_from_keyserver"
+    )
+    mocker.patch(
+        "craft_archives.repo.apt_key_manager.AptKeyManager.is_key_installed",
+        return_value=False,
+    )
+
+    package_repo = PackageRepositoryAptUCA(cloud="antelope")
+    updated = apt_gpg.install_package_repository_key(package_repo=package_repo)
+
+    assert updated is True
+    assert mock_install_key_from_keyserver.mock_calls == [
+        call(key_id="FAKE-UCA-KEY-ID", key_server="keyserver.ubuntu.com")
     ]

--- a/tests/unit/repo/test_apt_uca.py
+++ b/tests/unit/repo/test_apt_uca.py
@@ -1,0 +1,45 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import http
+import urllib.error
+from unittest.mock import Mock, patch
+
+import pytest
+from craft_archives.repo import apt_uca, errors
+
+
+@patch("urllib.request.urlopen", return_value=Mock(status=http.HTTPStatus.OK))
+def test_check_release_compatibility(urllib):
+    assert apt_uca.check_release_compatibility("jammy", "antelope") is None
+
+
+@patch("urllib.request.urlopen", side_effect=urllib.error.HTTPError("", http.HTTPStatus.NOT_FOUND, "NOT FOUND", {}, None))  # type: ignore
+def test_check_release_compatibility_invalid(urllib):
+    with pytest.raises(
+        errors.AptUCAInstallError,
+        match="Failed to install UCA 'invalid-cloud/updates': not a valid release for 'jammy'",
+    ):
+        apt_uca.check_release_compatibility("jammy", "invalid-cloud")
+
+
+@patch("urllib.request.urlopen", side_effect=urllib.error.HTTPError("", http.HTTPStatus.BAD_GATEWAY, "BAD GATEWAY", {}, None))  # type: ignore
+def test_check_release_compatibility_bad_gateway(urllib):
+    with pytest.raises(
+        errors.AptUCAInstallError,
+        match="Failed to install UCA 'antelope/updates': unexpected status code 502: 'BAD GATEWAY' while fetching release",
+    ):
+        apt_uca.check_release_compatibility("jammy", "antelope")

--- a/tests/unit/repo/test_installer.py
+++ b/tests/unit/repo/test_installer.py
@@ -18,6 +18,7 @@ from craft_archives.repo import installer
 from craft_archives.repo.package_repository import (
     PackageRepositoryApt,
     PackageRepositoryAptPPA,
+    PackageRepositoryAptUCA,
 )
 
 
@@ -43,10 +44,15 @@ def test_unmarshal_repositories():
             "key-id": "ABCDE12345" * 4,
             "priority": -2,
         },
+        {
+            "type": "apt",
+            "cloud": "antelope",
+            "pocket": "proposed",
+        },
     ]
 
     pkg_repos = installer._unmarshal_repositories(data)
-    assert len(pkg_repos) == 4
+    assert len(pkg_repos) == 5
     assert isinstance(pkg_repos[0], PackageRepositoryAptPPA)
     assert pkg_repos[0].ppa == "test/somerepo"
     assert pkg_repos[0].priority is None
@@ -58,3 +64,6 @@ def test_unmarshal_repositories():
     assert isinstance(pkg_repos[3], PackageRepositoryApt)
     assert pkg_repos[2].priority == -1
     assert pkg_repos[3].priority == -2
+    assert isinstance(pkg_repos[4], PackageRepositoryAptUCA)
+    assert pkg_repos[4].cloud == "antelope"
+    assert pkg_repos[4].pocket == "proposed"

--- a/tests/unit/repo/test_projects.py
+++ b/tests/unit/repo/test_projects.py
@@ -17,12 +17,23 @@
 import pydantic
 import pytest
 from craft_archives.repo import errors
-from craft_archives.repo.projects import Apt, AptDeb, AptPPA
+from craft_archives.repo.projects import (
+    Apt,
+    AptDeb,
+    AptPPA,
+    AptUCA,
+    validate_repository,
+)
 
 
 @pytest.fixture
 def ppa_dict():
     return {"type": "apt", "ppa": "test/somerepo"}
+
+
+@pytest.fixture
+def uca_dict():
+    return {"type": "apt", "cloud": "antelope", "pocket": "updates"}
 
 
 class TestAptPPAValidation:
@@ -55,6 +66,38 @@ class TestAptPPAValidation:
         error = "unexpected value; permitted: 'apt'"
         with pytest.raises(pydantic.ValidationError, match=error):
             AptPPA.unmarshal(repo)
+
+
+class TestAptUCAValidation:
+    """AptUCA field validation."""
+
+    @pytest.mark.parametrize(
+        "priority", ["always", "prefer", "defer", 1000, 990, 500, 100, -1, None]
+    )
+    def test_apt_uca_valid(self, priority, uca_dict):
+        if priority is not None:
+            uca_dict["priority"] = priority
+        apt_uca = AptUCA.unmarshal(uca_dict)
+        assert apt_uca.type == "apt"
+        assert apt_uca.cloud == "antelope"
+        assert apt_uca.priority == priority
+
+    def test_apt_uca_repository_invalid(self):
+        repo = {
+            "cloud": "antelope",
+        }
+        error = r"type\s+field required"
+        with pytest.raises(pydantic.ValidationError, match=error):
+            AptUCA.unmarshal(repo)
+
+    def test_project_package_uca_repository_bad_type(self):
+        repo = {
+            "type": "invalid",
+            "cloud": "antelope",
+        }
+        error = "unexpected value; permitted: 'apt'"
+        with pytest.raises(pydantic.ValidationError, match=error):
+            AptUCA.unmarshal(repo)
 
 
 class TestAptDebValidation:
@@ -160,6 +203,7 @@ class TestAptDebValidation:
                 "formats": ["deb"],
             },
         ),
+        (AptUCA, {"type": "apt", "cloud": "antelope"}),
     ],
 )
 def test_apt_unmarshal_returns_correct_subclass(subclass, value):
@@ -177,6 +221,28 @@ def test_apt_unmarshal_returns_correct_subclass(subclass, value):
 def test_validation_failure(error_class, kwargs):
     with pytest.raises(error_class):
         Apt(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "repo",
+    [
+        {"type": "apt", "ppa": "ppa/ppa"},
+        {
+            "type": "apt",
+            "url": "https://deb.repo",
+            "key-id": "A" * 40,
+            "formats": ["deb"],
+        },
+        {"type": "apt", "cloud": "antelope"},
+    ],
+)
+def test_validate_repository(repo):
+    validate_repository(repo)
+
+
+def test_validate_repository_invalid():
+    with pytest.raises(TypeError, match="must be a dictionary"):
+        validate_repository("invalid repository")  # type: ignore
 
 
 # endregion

--- a/tests/unit/repo/test_projects.py
+++ b/tests/unit/repo/test_projects.py
@@ -245,4 +245,9 @@ def test_validate_repository_invalid():
         validate_repository("invalid repository")  # type: ignore
 
 
+def test_validate_repository_empty_dict():
+    with pytest.raises(pydantic.ValidationError):
+        validate_repository({})
+
+
 # endregion


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?
  * `lint-pyright` fails, no logs about why

-----
Example of rockcraft.yaml:
```yaml
name: keystone
summary: Openstack Keystone
license: Apache-2.0
description: |
  Ubuntu distribution of OpenStack Keystone
version: antelope

base: ubuntu:22.04
platforms:
  amd64:

package-repositories:
  - type: apt
    cloud: antelope
    pocket: updates
    priority: always

parts:
  keystone:
    plugin: nil
    stage-packages:
      - apache2
      - keystone
```