### PR TITLE
ci: remove ubuntu-18.04 platform

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        platform: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        platform: [ubuntu-20.04, ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Looks like support for this release is finally being removed. This means that applications will need to test the platform themselves (via e.g. spread tests).

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
