### PR TITLE
Add a fuller integration test, and multiple minor changes to support it

### DIFF
--- a/craft_archives/repo/apt_key_manager.py
+++ b/craft_archives/repo/apt_key_manager.py
@@ -134,18 +134,15 @@ class AptKeyManager:
                 fingerprints.append(line[4:].decode().strip(":"))
         return fingerprints
 
-    @classmethod
-    def is_key_installed(
-        cls, *, key_id: str, keyring_path: pathlib.Path = KEYRINGS_PATH
-    ) -> bool:
+    def is_key_installed(self, *, key_id: str) -> bool:
         """Check if specified key_id is installed.
 
-        :param key_id: Key ID to check for.
-        :param keyring_path: An optional override to check for the keyring.
+        :param key_id: Key ID to check for. The key will be looked for in the
+          AptKeyManager's configured keyrings path.
 
         :returns: True if key is installed.
         """
-        keyring_file = get_keyring_path(key_id, base_path=keyring_path)
+        keyring_file = get_keyring_path(key_id, base_path=self._keyrings_path)
         # Check if the keyring file exists first, otherwise the gpg check itself
         # creates it.
         if not keyring_file.is_file():

--- a/craft_archives/repo/apt_key_manager.py
+++ b/craft_archives/repo/apt_key_manager.py
@@ -86,10 +86,10 @@ class AptKeyManager:
     def __init__(
         self,
         *,
-        keyrings_path: pathlib.Path = KEYRINGS_PATH,
+        keyrings_path: Optional[pathlib.Path] = None,
         key_assets: pathlib.Path,
     ) -> None:
-        self._keyrings_path = keyrings_path
+        self._keyrings_path = keyrings_path or KEYRINGS_PATH
         self._key_assets = key_assets
 
     def find_asset_with_key_id(self, *, key_id: str) -> Optional[pathlib.Path]:

--- a/craft_archives/repo/apt_preferences_manager.py
+++ b/craft_archives/repo/apt_preferences_manager.py
@@ -108,11 +108,11 @@ class AptPreferencesManager:
     def __init__(
         self,
         *,
-        path: Path = _DEFAULT_PREFERENCES_FILE,
+        path: typing.Optional[Path] = None,
         header: str = _DEFAULT_HEADER,
     ) -> None:
         self._header = header
-        self._path = path
+        self._path = path or _DEFAULT_PREFERENCES_FILE
         self._preferences: typing.List[Preference] = []
 
     def read(self) -> None:

--- a/craft_archives/repo/apt_sources_manager.py
+++ b/craft_archives/repo/apt_sources_manager.py
@@ -82,11 +82,11 @@ class AptSourcesManager:
     def __init__(
         self,
         *,
-        sources_list_d: Path = _DEFAULT_SOURCES_DIRECTORY,
-        keyrings_dir: Path = apt_key_manager.KEYRINGS_PATH,
+        sources_list_d: Optional[Path] = None,
+        keyrings_dir: Optional[Path] = None,
     ) -> None:
-        self._sources_list_d = sources_list_d
-        self._keyrings_dir = keyrings_dir
+        self._sources_list_d = sources_list_d or _DEFAULT_SOURCES_DIRECTORY
+        self._keyrings_dir = keyrings_dir or apt_key_manager.KEYRINGS_PATH
 
     def _install_sources(
         self,

--- a/craft_archives/repo/apt_sources_manager.py
+++ b/craft_archives/repo/apt_sources_manager.py
@@ -102,7 +102,7 @@ class AptSourcesManager:
         """Install sources list configuration.
 
         Write config to:
-        /etc/apt/sources.list.d/snapcraft-<name>.sources
+        /etc/apt/sources.list.d/craft-<name>.sources
 
         :returns: True if configuration was changed.
         """
@@ -119,7 +119,7 @@ class AptSourcesManager:
         )
 
         if name not in ["default", "default-security"]:
-            name = "snapcraft-" + name
+            name = "craft-" + name
 
         config_path = self._sources_list_d / f"{name}.sources"
         if config_path.exists() and config_path.read_text() == config:

--- a/tests/integration/repo/test_apt_key_manager.py
+++ b/tests/integration/repo/test_apt_key_manager.py
@@ -50,25 +50,25 @@ def apt_gpg(key_assets, tmp_path):
 def test_install_key(apt_gpg, tmp_path, test_keys_dir):
     expected_file = tmp_path / "craft-FC42E99D.gpg"
     assert not expected_file.exists()
-    assert not apt_gpg.is_key_installed(key_id="FC42E99D", keyring_path=tmp_path)
+    assert not apt_gpg.is_key_installed(key_id="FC42E99D")
 
     keypath = test_keys_dir / "FC42E99D.asc"
     apt_gpg.install_key(key=keypath.read_text())
 
     assert expected_file.is_file()
-    assert apt_gpg.is_key_installed(key_id="FC42E99D", keyring_path=tmp_path)
+    assert apt_gpg.is_key_installed(key_id="FC42E99D")
 
 
 def test_install_key_from_keyserver(apt_gpg, tmp_path):
     expected_file = tmp_path / "craft-FC42E99D.gpg"
     assert not expected_file.exists()
-    assert not apt_gpg.is_key_installed(key_id="FC42E99D", keyring_path=tmp_path)
+    assert not apt_gpg.is_key_installed(key_id="FC42E99D")
 
     key_id = "78E1918602959B9C59103100F1831DDAFC42E99D"
     apt_gpg.install_key_from_keyserver(key_id=key_id)
 
     assert expected_file.is_file()
-    assert apt_gpg.is_key_installed(key_id="FC42E99D", keyring_path=tmp_path)
+    assert apt_gpg.is_key_installed(key_id="FC42E99D")
 
 
 def test_install_key_missing_directory(key_assets, tmp_path, test_keys_dir):

--- a/tests/integration/repo/test_apt_key_manager.py
+++ b/tests/integration/repo/test_apt_key_manager.py
@@ -58,6 +58,10 @@ def test_install_key(apt_gpg, tmp_path, test_keys_dir):
     assert expected_file.is_file()
     assert apt_gpg.is_key_installed(key_id="FC42E99D")
 
+    # Check that gpg's backup file has been removed
+    backup_file = expected_file.with_suffix(expected_file.suffix + "~")
+    assert not backup_file.is_file()
+
 
 def test_install_key_from_keyserver(apt_gpg, tmp_path):
     expected_file = tmp_path / "craft-FC42E99D.gpg"

--- a/tests/integration/repo/test_installer.py
+++ b/tests/integration/repo/test_installer.py
@@ -1,0 +1,221 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Integration tests for repo.installer"""
+
+import shutil
+from pathlib import Path
+from textwrap import dedent
+from typing import Any, Dict, List
+
+import pytest
+from craft_archives import os_release, repo
+
+APT_SOURCES = dedent(
+    """
+    Types: deb deb-src
+    URIs: http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu
+    Suites: focal
+    Components: main
+    Architectures: amd64
+    Signed-By: {key_location}/craft-FC42E99D.gpg
+    """
+).lstrip()
+
+VERSION_CODENAME = os_release.OsRelease().version_codename()
+
+PPA_SOURCES = dedent(
+    """
+    Types: deb
+    URIs: http://ppa.launchpad.net/deadsnakes/ppa/ubuntu
+    Suites: {codename}
+    Components: main
+    Architectures: amd64
+    Signed-By: {key_location}/craft-6A755776.gpg
+    """
+).lstrip()
+
+# Needed because some "clouds" are only available for specific Ubuntu releases
+RELEASE_TO_CLOUD = {
+    "jammy": {"cloud": "antelope", "codename": "jammy"},
+    "focal": {"cloud": "wallaby", "codename": "focal"},
+}
+
+CLOUD_DATA = RELEASE_TO_CLOUD[VERSION_CODENAME]
+
+CLOUD_SOURCES = dedent(
+    """
+    Types: deb
+    URIs: http://ubuntu-cloud.archive.canonical.com/ubuntu
+    Suites: {codename}-updates/{cloud}
+    Components: main
+    Architectures: amd64
+    Signed-By: {key_location}/craft-EC4926EA.gpg
+    """
+).lstrip()
+
+PREFERENCES = dedent(
+    """
+    # This file is managed by craft-archives
+    Package: *
+    Pin: origin "ppa.launchpad.net"
+    Pin-Priority: 100
+
+    Package: *
+    Pin: release o=LP-PPA-deadsnakes-ppa
+    Pin-Priority: 1000
+
+    Package: *
+    Pin: origin "ubuntu-cloud.archive.canonical.com"
+    Pin-Priority: 123
+
+    """
+).lstrip()
+
+
+@pytest.fixture
+def fake_etc_apt(tmp_path, mocker) -> Path:
+    """Mock the default paths used to store keys, sources and preferences."""
+    etc_apt = tmp_path / "etc/apt"
+    etc_apt.mkdir(parents=True)
+
+    keyrings_dir = etc_apt / "keyrings"
+    keyrings_dir.mkdir()
+    mocker.patch("craft_archives.repo.apt_key_manager.KEYRINGS_PATH", new=keyrings_dir)
+
+    sources_dir = etc_apt / "sources.list.d"
+    sources_dir.mkdir()
+    mocker.patch(
+        "craft_archives.repo.apt_sources_manager._DEFAULT_SOURCES_DIRECTORY",
+        new=sources_dir,
+    )
+
+    preferences_dir = etc_apt / "preferences.d"
+    preferences_dir.mkdir()
+    preferences_dir = preferences_dir / "craft-archives"
+    mocker.patch(
+        "craft_archives.repo.apt_preferences_manager._DEFAULT_PREFERENCES_FILE",
+        new=preferences_dir,
+    )
+
+    return etc_apt
+
+
+@pytest.fixture()
+def all_repo_types() -> List[Dict[str, Any]]:
+    return [
+        # a "standard" repo, with a key coming from the assets dir
+        {
+            "type": "apt",
+            "formats": ["deb", "deb-src"],
+            "components": ["main"],
+            "suites": ["focal"],
+            "key-id": "78E1918602959B9C59103100F1831DDAFC42E99D",
+            "url": "http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu",
+            "priority": "defer",
+        },
+        # a "ppa" repo, with key coming from the ubuntu keyserver
+        {
+            "type": "apt",
+            "ppa": "deadsnakes/ppa",
+            "priority": "always",
+        },
+        # a "cloud" repo
+        {
+            "type": "apt",
+            "cloud": CLOUD_DATA["cloud"],
+            "pocket": "updates",
+            "priority": 123,
+        },
+    ]
+
+
+@pytest.fixture
+def test_keys_dir(tmp_path) -> Path:
+    source_dir = Path(__file__).parent / "test_keys"
+
+    key = source_dir / "FC42E99D.asc"
+    assert key.is_file()
+
+    target_dir = tmp_path / "keys"
+    target_dir.mkdir()
+
+    shutil.copy2(key, target_dir)
+
+    return target_dir
+
+
+def test_install(fake_etc_apt, all_repo_types, test_keys_dir):
+    """Integrated test that checks the configuration of keys, sources and pins."""
+
+    assert repo.install(project_repositories=all_repo_types, key_assets=test_keys_dir)
+
+    check_keyrings(fake_etc_apt)
+    check_sources(fake_etc_apt)
+    check_preferences(fake_etc_apt)
+
+
+def check_keyrings(etc_apt_dir: Path) -> None:
+    keyrings_dir = etc_apt_dir / "keyrings"
+
+    # Must have exactly these keyring files, one for each repo
+    expected_key_ids = ("6A755776", "FC42E99D", "EC4926EA")
+
+    assert len(list(keyrings_dir.iterdir())) == len(expected_key_ids)
+    for key_id in expected_key_ids:
+        keyring_file = keyrings_dir / f"craft-{key_id}.gpg"
+        assert keyring_file.is_file()
+
+
+def check_sources(etc_apt_dir: Path) -> None:
+    sources_dir = etc_apt_dir / "sources.list.d"
+
+    keyrings_location = etc_apt_dir / "keyrings"
+
+    cloud_name = CLOUD_DATA["cloud"]
+    codename = CLOUD_DATA["codename"]
+
+    # Must have exactly these sources files, one for each repo
+    source_to_contents = {
+        "http_ppa_launchpad_net_snappy_dev_snapcraft_daily_ubuntu": APT_SOURCES.format(
+            key_location=keyrings_location
+        ),
+        "ppa-deadsnakes_ppa": PPA_SOURCES.format(
+            codename=VERSION_CODENAME, key_location=keyrings_location
+        ),
+        f"cloud-{cloud_name}": CLOUD_SOURCES.format(
+            cloud=cloud_name,
+            codename=codename,
+            key_location=keyrings_location,
+        ),
+    }
+
+    assert len(list(keyrings_location.iterdir())) == len(source_to_contents)
+
+    for source_repo, expected_contents in source_to_contents.items():
+        source_file = sources_dir / f"snapcraft-{source_repo}.sources"
+        assert source_file.is_file()
+        assert source_file.read_text() == expected_contents
+
+
+def check_preferences(etc_apt_dir: Path) -> None:
+    # Exactly one "preferences" file
+    preferences_dir = etc_apt_dir / "preferences.d"
+    assert len(list(preferences_dir.iterdir())) == 1
+
+    preferences_file = preferences_dir / "craft-archives"
+    assert preferences_file.is_file()
+    assert preferences_file.read_text() == PREFERENCES

--- a/tests/integration/repo/test_installer.py
+++ b/tests/integration/repo/test_installer.py
@@ -206,7 +206,7 @@ def check_sources(etc_apt_dir: Path) -> None:
     assert len(list(keyrings_location.iterdir())) == len(source_to_contents)
 
     for source_repo, expected_contents in source_to_contents.items():
-        source_file = sources_dir / f"snapcraft-{source_repo}.sources"
+        source_file = sources_dir / f"craft-{source_repo}.sources"
         assert source_file.is_file()
         assert source_file.read_text() == expected_contents
 

--- a/tests/unit/repo/test_apt_key_manager.py
+++ b/tests/unit/repo/test_apt_key_manager.py
@@ -162,11 +162,11 @@ def test_is_key_installed(
 
     # If the keyring file doesn't exist at all the function should exit early,
     # with no gpg calls
-    assert not apt_gpg.is_key_installed(key_id="foo", keyring_path=keyring_path)
+    assert not apt_gpg.is_key_installed(key_id="foo")
     assert mock_run.mock_calls == []
 
     keyring_path.touch()
-    is_installed = apt_gpg.is_key_installed(key_id="foo", keyring_path=tmp_path)
+    is_installed = apt_gpg.is_key_installed(key_id="foo")
 
     assert is_installed is expected_is_installed
     assert mock_run.mock_calls == [
@@ -199,7 +199,7 @@ def test_is_key_installed_with_gpg_failure(
         cmd=["gpg"], returncode=return_code, output=b"some error"
     )
 
-    is_installed = apt_gpg.is_key_installed(key_id="foo", keyring_path=tmp_path)
+    is_installed = apt_gpg.is_key_installed(key_id="foo")
 
     assert is_installed is False
     mock_logger.warning.assert_called_once_with("gpg error: some error")

--- a/tests/unit/repo/test_apt_sources_manager.py
+++ b/tests/unit/repo/test_apt_sources_manager.py
@@ -88,7 +88,7 @@ def apt_sources_mgr(tmp_path):
                 suites=["test-suite1", "test-suite2"],
                 url="http://test.url/ubuntu",
             ),
-            "snapcraft-http_test_url_ubuntu.sources",
+            "craft-http_test_url_ubuntu.sources",
             dedent(
                 """\
                 Types: deb deb-src
@@ -109,7 +109,7 @@ def apt_sources_mgr(tmp_path):
                 suites=["test-suite1", "test-suite2"],
                 url="http://test.url/ubuntu",
             ),
-            "snapcraft-NO-FORMAT.sources",
+            "craft-NO-FORMAT.sources",
             dedent(
                 """\
                 Types: deb
@@ -128,7 +128,7 @@ def apt_sources_mgr(tmp_path):
                 path="some-path",
                 url="http://test.url/ubuntu",
             ),
-            "snapcraft-WITH-PATH.sources",
+            "craft-WITH-PATH.sources",
             dedent(
                 """\
                 Types: deb
@@ -145,7 +145,7 @@ def apt_sources_mgr(tmp_path):
                 name="IMPLIED-PATH",
                 url="http://test.url/ubuntu",
             ),
-            "snapcraft-IMPLIED-PATH.sources",
+            "craft-IMPLIED-PATH.sources",
             dedent(
                 """\
                 Types: deb
@@ -158,7 +158,7 @@ def apt_sources_mgr(tmp_path):
         ),
         (
             PackageRepositoryAptPPA(ppa="test/ppa"),
-            "snapcraft-ppa-test_ppa.sources",
+            "craft-ppa-test_ppa.sources",
             dedent(
                 """\
                 Types: deb
@@ -172,7 +172,7 @@ def apt_sources_mgr(tmp_path):
         ),
         (
             PackageRepositoryAptUCA(cloud="fake-cloud"),
-            "snapcraft-cloud-fake-cloud.sources",
+            "craft-cloud-fake-cloud.sources",
             dedent(
                 """\
                 Types: deb


### PR DESCRIPTION
This PR's main purpose is to add an integration test that exercises `repo.install()` covering the repository types that we currently support. In order to do this, I had to make multiple minor changes. The updates are applied over a handful of self-confined commits, which I hope will make the review easier. At merge time we can keep them as-is or squash 'em all, I don't have a strong preference either way.

CRAFT-1649
CRAFT-1682
