### PR TITLE
[EXPERIMENTAL] merge starbase/main

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,43 @@
+# Editor configuration options.
+# See: https://spec.editorconfig.org/
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[.editorconfig]
+max_line_length = off
+
+[Makefile]
+indent_style = tab
+
+[{*.py,*.pyi}]
+max_line_length = 88
+
+[{*.bash,*.sh,*.zsh}]
+indent_size = 2
+tab_width = 2
+
+[{*.har,*.json,*.json5}]
+indent_size = 2
+max_line_length = off
+
+[{*.markdown,*.md,*.rst}]
+max_line_length = off
+ij_visual_guides = none
+
+[{*.toml,Cargo.lock,Cargo.toml.orig,Gopkg.lock,Pipfile,poetry.lock}]
+max_line_length = off
+
+[{*.ini, *.cfg}]
+max_line_length = off
+
+[{*.yaml,*.yml}]
+indent_size = 2
+max_line_length = off

--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -18,7 +18,11 @@ categories:
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   Special thanks to the contributors that made this release happen: $CONTRIBUTORS
+<<<<<<< HEAD
   
+=======
+
+>>>>>>> starbase/main
   ## Full list of changes
 
   $CHANGES

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,18 +1,31 @@
+<<<<<<< HEAD
  {
+=======
+{
+>>>>>>> starbase/main
   // Configuration file for RenovateBot: https://docs.renovatebot.com/configuration-options
   extends: ["config:base"],
   labels: ["dependencies"],  // For convenient searching in GitHub
   pip_requirements: {
+<<<<<<< HEAD
     fileMatch: ["^tox.ini$"]
   },
   pip_setup: {
     fileMatch: ["^pyproject.toml$", "(^|/)setup\\.py$"]
+=======
+    fileMatch: ["^tox.ini$", "(^|/)requirements([\\w-]*)\\.txt$"]
+>>>>>>> starbase/main
   },
    packageRules: [
     {
       // Automerge patches, pin changes and digest changes.
       // Also groups these changes together.
+<<<<<<< HEAD
       groupName: "patch updates",
+=======
+      groupName: "bugfixes",
+      excludePackagePrefixes: ["dev", "lint", "types"],
+>>>>>>> starbase/main
       matchUpdateTypes: ["patch", "pin", "digest"],
       prPriority: 3, // Patches should go first!
       automerge: true
@@ -28,28 +41,70 @@
       // GitHub Actions are higher priority to update than most dependencies.
       groupName: "GitHub Actions",
       matchManagers: ["github-actions"],
+<<<<<<< HEAD
       prPriority: 1
+=======
+      prPriority: 1,
+      automerge: true,
+>>>>>>> starbase/main
     },
     // Everything not in one of these rules gets priority 0 and falls here.
     {
       // Minor changes can be grouped and automerged for dev dependencies, but are also deprioritised.
+<<<<<<< HEAD
       groupName: "development dependencies (minor and patch)",
       groupSlug: "dev-dependencies",
       matchDepTypes: ["devDependencies"],
+=======
+      groupName: "development dependencies (non-major)",
+      groupSlug: "dev-dependencies",
+      matchPackagePrefixes: [
+        "dev",
+        "lint",
+        "types"
+      ],
+      excludePackagePatterns: ["ruff"],
+>>>>>>> starbase/main
       matchUpdateTypes: ["minor", "patch", "pin", "digest"],
       prPriority: -1,
       automerge: true
     },
     {
+<<<<<<< HEAD
+=======
+      // Documentation related updates
+      groupName: "documentation dependencies",
+      groupSlug: "doc-dependencies",
+      matchPackageNames: ["Sphinx"],
+      matchPackagePatterns: ["^[Ss]phinx.*$", "^furo$"],
+      matchPackagePrefixes: ["docs"],
+    },
+    {
+>>>>>>> starbase/main
       // Other major dependencies get deprioritised below minor dev dependencies.
       matchUpdateTypes: ["major"],
       prPriority: -2
     },
     {
+<<<<<<< HEAD
       // Major dev dependencies are stone last.
       matchDepTypes: ["devDependencies"],
       matchUpdateTypes: ["major"],
       prPriority: -3
+=======
+      // Major dev dependencies are stone last, but grouped.
+      groupName: "development dependencies (major versions)",
+      groupSlug: "dev-dependencies",
+      matchDepTypes: ["devDependencies"],
+      matchUpdateTypes: ["major"],
+      prPriority: -3
+    },
+    {
+      // Ruff is still unstable, so update it separately.
+      groupName: "ruff",
+      matchPackagePatterns: ["^(lint/)?ruff$"],
+      prPriority: -3
+>>>>>>> starbase/main
     }
   ],
   regexManagers: [
@@ -58,14 +113,32 @@
       fileMatch: ["tox.ini"],
       depTypeTemplate: "devDependencies",
       matchStrings: [
+<<<<<<< HEAD
         "# renovate: datasource=(?<datasource>\S+)\n\s+(?<depName>.*?)(\[[\w]*\])*[=><]=?(?<currentValue>.*?)\n"
+=======
+        "# renovate: datasource=(?<datasource>\\S+)\n\\s+(?<depName>.*?)(\\[[\\w]*\\])*[=><]=?(?<currentValue>.*?)\n"
+      ]
+    },
+    {
+      // .pre-commit-config.yaml version updates
+      fileMatch: [".pre-commit-config.yaml"],
+      depTypeTemplate: "devDependencies",
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>\\S+);\\s*depName=(?<depName>.*?)\n\s+rev: \"v?(?<currentValue>.*?)\""
+>>>>>>> starbase/main
       ]
     }
   ],
   timezone: "Etc/UTC",
+<<<<<<< HEAD
   automergeSchedule: "after 1 am and before 7 am",
   schedule: "every weekend",
   prConcurrentLimit: 5, // No more than 5 open PRs at a time.
+=======
+  automergeSchedule: "every weekend",
+  schedule: "every weekend",
+  prConcurrentLimit: 2, // No more than 2 open PRs at a time.
+>>>>>>> starbase/main
   prCreation: "not-pending", // Wait until status checks have completed before raising the PR
   prNotPendingHours: 4, // ...unless the status checks have been running for 4+ hours.
   prHourlyLimit: 1, // No more than 1 PR per hour.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,37 @@
+name: Documentation
+on:
+  push:
+    branches:
+      - "main"
+      - "feature/*"
+      - "hotfix/*"
+      - "release/*"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yaml"
+
+jobs:
+  sphinx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install Tox
+        run: pip install tox
+      - name: Lint documentation
+        run: tox run -e lint-docs
+      - name: Build documentation
+        run: tox run -e build-docs
+      - name: Upload documentation
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: docs/_build/

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   update_release_draft:
+<<<<<<< HEAD
     permissions:
       # write permission is required to create a github release
       contents: write
@@ -18,5 +19,11 @@ jobs:
     steps:
       - name: Release Drafter
         uses: release-drafter/release-drafter@v5
+=======
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@v5.23.0
+>>>>>>> starbase/main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,7 +72,11 @@ jobs:
           directory: ./results/
           files: coverage*.xml
       - name: Upload test results
+<<<<<<< HEAD
         if: always()
+=======
+        if: success() || failure()
+>>>>>>> starbase/main
         uses: actions/upload-artifact@v3
         with:
           name: test-results-${{ matrix.platform }}

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,9 @@ dmypy.json
 
 # Test results
 /results/
+<<<<<<< HEAD
+=======
+
+# direnv
+.envrc
+>>>>>>> starbase/main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # renovate: datasource=pypi;depName=ruff
+    rev: "v0.0.267"
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/psf/black
+    # renovate: datasource=pypi;depName=black
+    rev: "23.3.0"
+    hooks:
+      - id: black
+  - repo: https://github.com/adrienverge/yamllint.git
+    # renovate: datasource=pypi;depName=yamllint
+    rev: "v1.31.0"
+    hooks:
+      - id: yamllint

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,27 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+  - epub
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,12 @@
+---
+ignore-from-file: [.gitignore]
+
+extends: default
+
+rules:
+  document-start: disable
+  float-values: enable
+  line-length: disable
+  octal-values: enable
+  truthy:
+    check-keys: false

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -1,8 +1,16 @@
+<<<<<<< HEAD
 **************
 craft-archives
 **************
 
 Welcome to craft-archives! We hope this document helps you get started. Before contributing any code, please sign the `Canonical contributor licence agreement`_.
+=======
+*********
+Starcraft
+*********
+
+Welcome to Starcraft! We hope this document helps you get started. Before contributing any code, please sign the `Canonical contributor licence agreement`_.
+>>>>>>> starbase/main
 
 Setting up a development environment
 ------------------------------------
@@ -16,6 +24,10 @@ We use a large number of tools for our project. Most of these are installed for 
 - tox_ version 4 or later. (3.8+ will automatically provision a v4 virtualenv)
 - Pyright_ (it's recommended you install with ``snap install --classic pyright``)
 - ShellCheck_  (also available via snap: ``snap install shellcheck``)
+<<<<<<< HEAD
+=======
+- pre-commit_
+>>>>>>> starbase/main
 
 Once you have all of those installed, you can install the necessary virtual environments for this repository using tox.
 
@@ -44,10 +56,39 @@ If you'd like to run the tests with a newer version of Python, you can pass a sp
 
     tox -e test-py310
 
+<<<<<<< HEAD
+=======
+While the use of pre-commit_ is optional, it is highly encouraged, as it runs automatic fixes for files when `git commit` is called, including code formatting with ``black`` and ``ruff``.  The versions available in ``apt`` from Debian 11 (bullseye), Ubuntu 22.04 (jammy) and newer are sufficient, but you can also install the latest with ``pip install pre-commit``. Once you've installed it, run ``pre-commit install`` in this git repository to install the pre-commit hooks.
+
+Tox environments and labels
+###########################
+
+We group tox environments with the following labels:
+
+* ``format``: Runs all code formatters with auto-fixing
+* ``type``: Runs all type checkers
+* ``lint``: Runs all linters (including type checkers)
+* ``unit-tests``: Runs unit tests in Python versions on supported LTS's + latest
+* ``integration-tests``: Same as above but for integration tests
+* ``tests``: The union of ``unit-tests`` and ``integration-tests``
+
+For each of these, you can see which environments will be run with ``tox list``. For example:
+
+    tox list -m lint
+
+You can also see all the environments by simply running ``tox list``
+
+Running ``tox run -m format`` and ``tox run -m lint`` before committing code is recommended.
+
+>>>>>>> starbase/main
 .. _Black: https://black.readthedocs.io
 .. _`Canonical contributor licence agreement`: http://www.ubuntu.com/legal/contributors/
 .. _deadsnakes: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa
 .. _`git submodules`: https://git-scm.com/book/en/v2/Git-Tools-Submodules#_cloning_submodules
+<<<<<<< HEAD
+=======
+.. _pre-commit: https://pre-commit.com/
+>>>>>>> starbase/main
 .. _pyproject.toml: ./pyproject.toml
 .. _Pyright: https://github.com/microsoft/pyright
 .. _pytest: https://pytest.org

--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,37 @@
+<<<<<<< HEAD
 TODO for craft-archives
+=======
+********
+starbase
+********
+
+A base repository for Starcraft projects.
+
+Description
+-----------
+This project is designed to act as the basis for any future starcraft projects as well as a testbed for any tooling changes we want to make before merging them into other projects.
+
+Structure
+---------
+TODO
+
+How to migrate existing projects
+--------------------------------
+TODO
+
+How to create a new project
+---------------------------
+[TODO: Make this a template repository.]
+
+1. [Use this template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) to create your repository.
+2. Ensure the ``LICENSE`` file represents the current best practices from the Canonical legal team for the specific project you intend to release. (LGPL v3 for libraries, GPL v3 for applications.)
+3. Rename any files or directories and ensure references are updated.
+4. Replace any appropriate `starcraft` references with the appropriate name.
+5. Put correct contact information into CODE_OF_CONDUCT.md
+6. Write a new README
+7. Import your documentation to ReadTheDocs_.
+
+.. _EditorConfig: https://editorconfig.org/
+.. _pre-commit: https://pre-commit.com/
+.. _ReadTheDocs: https://docs.readthedocs.io/en/stable/intro/import-guide.html
+>>>>>>> starbase/main

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,11 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+<<<<<<< HEAD
 project = "craft-archives"
+=======
+project = "starcraft"
+>>>>>>> starbase/main
 copyright = "2023, Canonical"
 author = "Canonical"
 
@@ -57,6 +61,10 @@ always_document_param_types = True
 
 # Github config
 github_username = "canonical"
+<<<<<<< HEAD
 github_repository = "craft-archives"
+=======
+github_repository = "starcraft-base"
+>>>>>>> starbase/main
 
 # endregion

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -5,5 +5,8 @@ How-to guides
 
 .. toctree::
    :maxdepth: 1
+<<<<<<< HEAD
 
    add_repo
+=======
+>>>>>>> starbase/main

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 .. craft-archives documentation root file
 
 Craft Archives
@@ -14,6 +15,12 @@ that other tools and packages can use to work with software archives.
 
 This package is most useful for implementers of tools using the Craft Parts
 framework that need to provide support for additional software archives.
+=======
+.. starcraft documentation root file
+
+StarCraft
+=========
+>>>>>>> starbase/main
 
 .. toctree::
    :maxdepth: 1
@@ -28,7 +35,11 @@ framework that need to provide support for additional software archives.
 
    .. grid-item-card:: :ref:`Tutorial <tutorial>`
 
+<<<<<<< HEAD
       **Get started** with a hands-on introduction to Craft Archives
+=======
+      **Get started** with a hands-on introduction to Starcraft
+>>>>>>> starbase/main
 
    .. grid-item-card:: :ref:`How-to guides <howto>`
 
@@ -39,7 +50,11 @@ framework that need to provide support for additional software archives.
 
    .. grid-item-card:: :ref:`Reference <reference>`
 
+<<<<<<< HEAD
       **Technical information** about Craft Archives
+=======
+      **Technical information** about Starcraft
+>>>>>>> starbase/main
 
    .. grid-item-card:: :ref:`Explanation <explanation>`
 
@@ -48,12 +63,20 @@ framework that need to provide support for additional software archives.
 Project and community
 =====================
 
+<<<<<<< HEAD
 Craft Archives is a member of the Canonical family. It's an open source project
+=======
+Starcraft is a member of the Canonical family. It's an open source project
+>>>>>>> starbase/main
 that warmly welcomes community projects, contributions, suggestions, fixes
 and constructive feedback.
 
 * `Ubuntu Code of Conduct <https://ubuntu.com/community/code-of-conduct>`_.
+<<<<<<< HEAD
 * `Canonical contributor licence agreement
+=======
+* `Canonical contributor licenses agreement
+>>>>>>> starbase/main
   <https://ubuntu.com/legal/contributors>`_.
 
 Indices and tables

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -6,8 +6,11 @@ Reference
 .. toctree::
    :maxdepth: 1
 
+<<<<<<< HEAD
    repo_properties
 
+=======
+>>>>>>> starbase/main
 Indices and tables
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [project]
+<<<<<<< HEAD
 name = "craft-archives"
 version = "0.0.4"
 readme = "README.rst"
@@ -9,20 +10,30 @@ dependencies = [
     "lazr.uri",
     "overrides",
     "pydantic",
+=======
+name = "starcraft"
+dynamic = ["version", "readme"]
+dependencies = [
+
+>>>>>>> starbase/main
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
     "License :: OSI Approved :: GNU General Public License (GPL)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
+<<<<<<< HEAD
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+=======
+>>>>>>> starbase/main
 ]
 requires-python = ">=3.8"
 
 [project.scripts]
+<<<<<<< HEAD
 
 [project.optional-dependencies]
 dev = [
@@ -46,6 +57,33 @@ docs = [
     "sphinx-autobuild==2021.3.14",
     "sphinx-copybutton==0.5.1",
     "sphinx-design==0.3.0",
+=======
+starcraft-hello = "starcraft:hello"
+
+[project.optional-dependencies]
+dev = [
+    "coverage[toml]==7.2.5",
+    "pytest==7.3.1",
+    "pytest-cov==4.0.0",
+    "pytest-mock==3.10.0",
+]
+lint = [
+    "black==23.3.0",
+    "codespell[toml]==2.2.4",
+    "ruff==0.0.269",
+    "yamllint==1.31.0"
+]
+types = [
+    "mypy[reports]==1.3.0",
+    "pyright==1.1.309",
+]
+docs = [
+    "furo==2023.3.27",
+    "sphinx>=6.2.1,<7.0",
+    "sphinx-autobuild==2021.3.14",
+    "sphinx-copybutton==0.5.2",
+    "sphinx-design==0.4.1",
+>>>>>>> starbase/main
     "sphinx-pydantic==0.1.1",
     "sphinx-toolbox==3.4.0",
     "sphinx-lint==0.6.7",
@@ -53,27 +91,51 @@ docs = [
 
 [build-system]
 requires = [
+<<<<<<< HEAD
     "setuptools==67.6.0",
 ]
 build-backend = "setuptools.build_meta"
 
+=======
+    "setuptools==67.7.2",
+    "setuptools_scm[toml]>=7.1"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+readme = {file = "README.rst"}
+
+>>>>>>> starbase/main
 [tool.setuptools.packages.find]
 exclude = [
     "dist",
     "docs",
     "results",
+<<<<<<< HEAD
     "test*",
 ]
 
+=======
+    "tests",
+]
+
+
+>>>>>>> starbase/main
 [tool.black]
 target-version = ["py38"]
 
 [tool.codespell]
 ignore-words-list = "buildd,crate,keyserver,comandos,ro,dedent,dedented"
+<<<<<<< HEAD
 skip = ".tox,.git,build,.*_cache,__pycache__,*.tar,*.snap,*.png,./node_modules,./docs/_build"
 quiet-level = 3
 check-filenames = true
 exclude-file = ".codespell_ignore_lines"
+=======
+skip = ".tox,.git,build,.*_cache,__pycache__,*.tar,*.snap,*.png,./node_modules,./docs/_build,.direnv,.venv,venv,.vscode"
+quiet-level = 3
+check-filenames = true
+>>>>>>> starbase/main
 
 [tool.isort]
 multi_line_output = 3
@@ -91,6 +153,7 @@ xfail_strict = true
 [tool.coverage.run]
 branch = true
 parallel = true
+<<<<<<< HEAD
 omit = [
     "tests/**",
     "craft_archives/os_release.py",
@@ -106,6 +169,18 @@ pythonVersion = "3.8"
 pythonPlatform = "Linux"
 venvPath = ".tox"
 venv = "typing"
+=======
+omit = ["tests/**"]
+
+[tool.coverage.report]
+skip_empty = true
+fail_under = 80
+
+[tool.pyright]
+strict = ["starcraft"]
+pythonVersion = "3.8"
+pythonPlatform = "Linux"
+>>>>>>> starbase/main
 
 [tool.mypy]
 python_version = "3.8"
@@ -124,7 +199,11 @@ disallow_untyped_decorators = true
 disallow_any_generics = true
 
 [[tool.mypy.overrides]]
+<<<<<<< HEAD
 module = ["craft_archives"]
+=======
+module = ["starcraft"]
+>>>>>>> starbase/main
 disallow_untyped_defs = true
 no_implicit_optional = true
 
@@ -135,15 +214,22 @@ strict = false
 [tool.ruff]
 line-length = 88
 target-version = "py38"
+<<<<<<< HEAD
 src = ["craft_archives", "tests"]
+=======
+src = ["starcraft", "tests"]
+>>>>>>> starbase/main
 extend-exclude = [
     "docs",
     "__pycache__",
 ]
+<<<<<<< HEAD
 pep8-naming.classmethod-decorators = [
     "pydantic.validator"
 ]
 
+=======
+>>>>>>> starbase/main
 # Follow ST063 - Maintaining and updating linting specifications for updating these.
 select = [  # Base linting rule selections.
     # See the internal document for discussion:
@@ -165,7 +251,12 @@ select = [  # Base linting rule selections.
     "ISC",  # Implicit string concatenation that can cause subtle issues
     "ICN",  # Only use common conventions for import aliases.
     "Q",  # Consistent quotations
+<<<<<<< HEAD
     "RET"  # Simpler logic after return, raise, continue or break
+=======
+    "RET",  # Simpler logic after return, raise, continue or break
+    "UP018", "C408",  # Convert type calls to literals. The latest pylint enforces this, but ruff has auto-fixes.
+>>>>>>> starbase/main
 ]
 extend-select = [
     # These sets are still frequently getting new rules.
@@ -212,8 +303,12 @@ ignore = [
     "S101",  # Allow assertions in tests
     "S103", # Allow `os.chmod` setting a permissive mask `0o555` on file or directory
     "S108", # Allow Probable insecure usage of temporary file or directory
+<<<<<<< HEAD
     "PLR0913", # Too many arguments to function
     "PLR2004", # Allow magic values used in comparisons
+=======
+    "PLR0913",  # Allow many arguments for test functions
+>>>>>>> starbase/main
 ]
 # isort leaves init files alone by default, this makes ruff ignore them too.
 "__init__.py" = ["I001"]

--- a/starcraft/__init__.py
+++ b/starcraft/__init__.py
@@ -1,0 +1,28 @@
+# This file is part of starcraft.
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Starcraft package demo."""
+from importlib.metadata import version
+from typing import List, Optional, Any
+
+__version__ = version(__name__)
+
+
+def hello(people: Optional[List[Any]] = None) -> None:
+    """Says hello."""
+    print("Hello *craft team!")
+    if people:
+        for person in people:
+            print(f"Hello {person}!")

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -1,0 +1,25 @@
+# This file is part of starcraft.
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Basic Starcraft package demo integration tests."""
+import subprocess
+
+
+def test_cli():
+    expected = "Hello *craft team!\n"
+
+    actual = subprocess.check_output(["starcraft-hello"], text=True)
+
+    assert expected == actual

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,0 +1,40 @@
+# This file is part of starcraft.
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Basic Starcraft package demo unit tests."""
+from unittest import mock
+
+from starcraft import hello
+
+
+def test_hello(mocker):
+    mocker.patch("builtins.print")
+
+    hello()
+
+    print.assert_called_once_with("Hello *craft team!")
+
+
+def test_hello_people(mocker):
+    mocker.patch("builtins.print")
+
+    hello(["people"])
+
+    print.assert_has_calls(
+        [
+            mock.call("Hello *craft team!"),
+            mock.call("Hello people!"),
+        ]
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,13 @@
 [tox]
 env_list =  # Environments to run when called with no parameters.
     lint-{black,ruff,pyright,shellcheck,codespell,docs}
+<<<<<<< HEAD
     test-py38
 minversion = 4.3.5
+=======
+    test-{py38,py310,py311}
+minversion = 4.5
+>>>>>>> starbase/main
 # Tox will use these requirements to bootstrap a venv if necessary.
 # tox-igore-env-name-mismatch allows us to have one virtualenv for all linting.
 # By setting requirements here, we make this INI file compatible with older
@@ -11,9 +16,13 @@ minversion = 4.3.5
 # install tox from apt. Older than that, the user gets an upgrade warning.
 requires =
     # renovate: datasource=pypi
+<<<<<<< HEAD
     tox==4.4.6
     # renovate: datasource=pypi
     tox-ignore-env-name-mismatch==0.2.0.post2
+=======
+    tox-ignore-env-name-mismatch>=0.2.0.post2
+>>>>>>> starbase/main
 # Allow tox to access the user's $TMPDIR environment variable if set.
 # This workaround is required to avoid circular dependencies for TMPDIR,
 # since tox will otherwise attempt to use the environment's TMPDIR variable.
@@ -34,7 +43,11 @@ extras = dev
 allowlist_externals = mkdir
 commands_pre = mkdir -p results
 
+<<<<<<< HEAD
 [testenv:test-{py38,py39,py310,py311,py312}]
+=======
+[testenv:test-{py38,py39,py310,py311,py312}]  # Configuration for all tests using pytest
+>>>>>>> starbase/main
 base = testenv, test
 description = Run unit tests with pytest
 labels =
@@ -50,15 +63,26 @@ commands = pytest {tty:--color=yes} --junit-xml=results/test-results-{env_name}.
 
 [lint]  # Standard linting configuration
 package = editable
+<<<<<<< HEAD
 extras = dev-lint
+=======
+extras = lint
+>>>>>>> starbase/main
 env_dir = {work_dir}/linting
 runner = ignore_env_name_mismatch
 
 [shellcheck]
+<<<<<<< HEAD
 find = find {tox_root} \( -name .git -o -name .tox \) -prune -o -print
 filter = file --mime-type -Nnf- | grep shellscript | cut -f1 -d:
 
 [testenv:lint-{black,ruff,shellcheck,codespell}]
+=======
+find = git ls-files
+filter = file --mime-type -Nnf- | grep shellscript | cut -f1 -d:
+
+[testenv:lint-{black,ruff,shellcheck,codespell,yaml}]
+>>>>>>> starbase/main
 description = Lint the source code
 base = testenv, lint
 labels = lint
@@ -68,6 +92,7 @@ commands_pre =
     shellcheck: bash -c '{[shellcheck]find} | {[shellcheck]filter} > {env_tmp_dir}/shellcheck_files'
 commands =
     black: black --check --diff {tty:--color} {posargs} .
+<<<<<<< HEAD
     ruff: ruff --diff --respect-gitignore {posargs} .
     shellcheck: xargs -ra {env_tmp_dir}/shellcheck_files shellcheck
     codespell: codespell --toml {tox_root}/pyproject.toml {posargs}
@@ -84,12 +109,30 @@ extras =
 labels = lint, type
 allowlist_externals =
     pyright: pyright
+=======
+    ruff: ruff check --respect-gitignore {posargs} .
+    shellcheck: xargs -ra {env_tmp_dir}/shellcheck_files shellcheck
+    codespell: codespell --toml {tox_root}/pyproject.toml {posargs}
+    yaml: yamllint {posargs} .
+
+[testenv:lint-{mypy,pyright}]
+description = Static type checking
+base = testenv, lint
+env_dir = {work_dir}/typing
+extras = dev, types
+labels = lint, type
+allowlist_externals =
+>>>>>>> starbase/main
     mypy: mkdir
 commands_pre =
     mypy: mkdir -p .mypy_cache
 commands =
     pyright: pyright {posargs}
+<<<<<<< HEAD
     mypy: mypy --install-types --non-interactive .
+=======
+    mypy: mypy --install-types --non-interactive {posargs:.}
+>>>>>>> starbase/main
 
 [testenv:format-{black,ruff,codespell}]
 description = Automatically format source code
@@ -107,17 +150,31 @@ no_package = true
 env_dir = {work_dir}/docs
 runner = ignore_env_name_mismatch
 
+<<<<<<< HEAD
 [testenv:sphinx-build]
+=======
+[testenv:build-docs]
+>>>>>>> starbase/main
 description = Build sphinx documentation
 base = docs
 allowlist_externals = bash
 commands_pre = bash -c 'if [[ ! -e docs ]];then echo "No docs directory. Run `tox run -e sphinx-quickstart` to create one.;";return 1;fi'
+<<<<<<< HEAD
 commands = sphinx-build {posargs:-b html} {tox_root}/docs {tox_root}/docs/_build
 
 [testenv:rundocs]
 description = Build documentation with an autoupdating server
 base = docs
 commands = sphinx-autobuild {posargs:-b html --open-browser --port 8080} --watch {tox_root}/craft_archives {tox_root}/docs {tox_root}/docs/_build
+=======
+# "-W" is to treat warnings as errors
+commands = sphinx-build {posargs:-b html} -W {tox_root}/docs {tox_root}/docs/_build
+
+[testenv:autobuild-docs]
+description = Build documentation with an autoupdating server
+base = docs
+commands = sphinx-autobuild {posargs:-b html --open-browser --port 8080} -W --watch {tox_root}/starcraft {tox_root}/docs {tox_root}/docs/_build
+>>>>>>> starbase/main
 
 [testenv:lint-docs]
 description = Lint the documentation with sphinx-lint


### PR DESCRIPTION
This is a little experiment into the workflow of updating craft-archives with starbase's changes. Here's what I did:

* Added canonical/starbase as a remote in my local craft-archives repo (remote called `starbase`);
* Created this `merge-starbase` branch;
* Merged `starbase/main` into the branch with `git merge starbase/main --allow-unrelated-histories`;
* Commited the merge, conflicts and all.

I left the conflicts in so we can see them on the diff. From the looks of it I think most conflicts are easy to solve (for many we can just keep craft-archives' version) and they show clearly the updates in starbase that are worth bringing in.

Comments??
