### PR TITLE
Release 1.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,14 @@
-TODO for craft-archives
+Craft Archives
+==============
+
+Craft Archives is a Python package to manage interaction with software
+archives on behalf of tools using the Craft Parts framework.
+
+Craft Archives provides a set of common interfaces to define the locations
+of software archives, install packages and verify their integrity.
+
+The aim of this package is to provide a uniform, extensible set of interfaces
+that other tools and packages can use to work with software archives.
+
+This package is most useful for implementers of tools using the Craft Parts
+framework that need to provide support for additional software archives.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,17 @@
+*********
+Changelog
+*********
+
+See the `Releases page`_ on Github for a complete list of commits that are
+included in each version.
+
+1.0.0 (2023-05-24)
+------------------
+
+This release marks the stability of craft-archives' API. Most of the work
+has been on internal refactorings and tooling.
+
+- Add support for Ubuntu Cloud Archive repositories
+- Unify package repositories representations
+
+.. _Releases page: https://github.com/canonical/craft-archives/releases

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -7,6 +7,7 @@ Reference
    :maxdepth: 1
 
    repo_properties
+   ../changelog
 
 Indices and tables
 ==================


### PR DESCRIPTION
1.0.0 (2023-05-23)
------------------

This release marks the stability of craft-archives' API. Most of the work
has been on internal refactorings and tooling.

- Add support for Ubuntu Cloud Archive repositories
- Unify package repositories representations
- Update many dependencies
- Documentation updates

Going to leave this as a Draft while I test this release on Snapcraft and Rockcraft
