### PR TITLE
repo: fix bad typing_extensions interaction

### DIFF
--- a/craft_archives/repo/package_repository.py
+++ b/craft_archives/repo/package_repository.py
@@ -30,6 +30,11 @@ from pydantic import (
     root_validator,  # pyright: ignore[reportUnknownVariableType]
     validator,  # pyright: ignore[reportUnknownVariableType]
 )
+
+# NOTE: using this instead of typing.Literal because of this bad typing_extensions
+# interaction: https://github.com/pydantic/pydantic/issues/5821#issuecomment-1559196859
+# We can revisit this when typing_extensions >4.6.0 is released, and/or we no longer
+# have to support Python <3.10
 from typing_extensions import Literal
 
 from . import errors

--- a/craft_archives/repo/package_repository.py
+++ b/craft_archives/repo/package_repository.py
@@ -19,7 +19,7 @@
 import abc
 import enum
 import re
-from typing import Any, Dict, List, Literal, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 from urllib.parse import urlparse
 
 import pydantic
@@ -30,6 +30,7 @@ from pydantic import (
     root_validator,  # pyright: ignore[reportUnknownVariableType]
     validator,  # pyright: ignore[reportUnknownVariableType]
 )
+from typing_extensions import Literal
 
 from . import errors
 


### PR DESCRIPTION
Ref: https://github.com/pydantic/pydantic/issues/5821#issuecomment-1559196859
We could also pin typing_extensions to 4.5.0 instead, but those pins have a tendency of sticking around.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
