### PR TITLE
repo: install package repositories in "arbitrary" paths

### DIFF
--- a/craft_archives/repo/__init__.py
+++ b/craft_archives/repo/__init__.py
@@ -16,10 +16,11 @@
 
 """Package repository helpers."""
 
-from .installer import install
+from .installer import install, install_in_root
 from .projects import validate_repository
 
 __all__ = [
     "install",
+    "install_in_root",
     "validate_repository",
 ]

--- a/craft_archives/repo/apt_key_manager.py
+++ b/craft_archives/repo/apt_key_manager.py
@@ -126,8 +126,8 @@ class AptKeyManager:
     ) -> pathlib.Path:
         """Get the location for Apt keyrings with ``root`` as the system root.
 
-        :param root: The optional system root to consider, or None to return the
-          default ``KEYRINGS_PATH``.
+        :param root: The optional system root to consider, or None to assume the standard
+          system root "/".
         """
         if root is None:
             return KEYRINGS_PATH

--- a/craft_archives/repo/apt_key_manager.py
+++ b/craft_archives/repo/apt_key_manager.py
@@ -121,6 +121,19 @@ class AptKeyManager:
         return None
 
     @classmethod
+    def keyrings_path_for_root(
+        cls, root: Optional[pathlib.Path] = None
+    ) -> pathlib.Path:
+        """Get the location for Apt keyrings with ``root`` as the system root.
+
+        :param root: The optional system root to consider, or None to return the
+          default ``KEYRINGS_PATH``.
+        """
+        if root is None:
+            return KEYRINGS_PATH
+        return root / "etc/apt/keyrings"
+
+    @classmethod
     def get_key_fingerprints(cls, *, key: str) -> List[str]:
         """List fingerprints found in specified key.
 

--- a/craft_archives/repo/apt_preferences_manager.py
+++ b/craft_archives/repo/apt_preferences_manager.py
@@ -119,8 +119,8 @@ class AptPreferencesManager:
     def preferences_path_for_root(cls, root: typing.Optional[Path] = None) -> Path:
         """Get the location for the Apt preferences file with ``root`` as the system root.
 
-        :param root: The optional system root to consider, or None to return the
-          default ``_DEFAULT_PREFERENCES_FILE``.
+        :param root: The optional system root to consider, or None to assume the standard
+          system root "/".
         """
         if root is None:
             return _DEFAULT_PREFERENCES_FILE

--- a/craft_archives/repo/apt_preferences_manager.py
+++ b/craft_archives/repo/apt_preferences_manager.py
@@ -115,6 +115,17 @@ class AptPreferencesManager:
         self._path = path or _DEFAULT_PREFERENCES_FILE
         self._preferences: typing.List[Preference] = []
 
+    @classmethod
+    def preferences_path_for_root(cls, root: typing.Optional[Path] = None) -> Path:
+        """Get the location for the Apt preferences file with ``root`` as the system root.
+
+        :param root: The optional system root to consider, or None to return the
+          default ``_DEFAULT_PREFERENCES_FILE``.
+        """
+        if root is None:
+            return _DEFAULT_PREFERENCES_FILE
+        return root / "etc/apt/preferences.d/craft-archives"
+
     def read(self) -> None:
         """Read the preferences file and populate Preferences objects."""
         if not self._path.exists():

--- a/craft_archives/repo/apt_sources_manager.py
+++ b/craft_archives/repo/apt_sources_manager.py
@@ -105,8 +105,8 @@ class AptSourcesManager:
     def sources_path_for_root(cls, root: Optional[Path] = None) -> Path:
         """Get the location for Apt source listings with ``root`` as the system root.
 
-        :param root: The optional system root to consider, or None to return the
-          default ``_DEFAULT_SOURCES_DIRECTORY``.
+        :param root: The optional system root to consider, or None to assume the standard
+          system root "/".
         """
         if root is None:
             return _DEFAULT_SOURCES_DIRECTORY

--- a/tests/unit/repo/test_apt_key_manager.py
+++ b/tests/unit/repo/test_apt_key_manager.py
@@ -15,12 +15,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 import subprocess
+from pathlib import Path
 from unittest import mock
 from unittest.mock import call
 
 import pytest
 from craft_archives.repo import apt_ppa, errors, package_repository
-from craft_archives.repo.apt_key_manager import AptKeyManager
+from craft_archives.repo.apt_key_manager import KEYRINGS_PATH, AptKeyManager
 from craft_archives.repo.package_repository import (
     PackageRepositoryApt,
     PackageRepositoryAptPPA,
@@ -468,3 +469,10 @@ def test_install_package_repository_key_uca_from_keyserver(apt_gpg, mocker):
     assert mock_install_key_from_keyserver.mock_calls == [
         call(key_id="FAKE-UCA-KEY-ID", key_server="keyserver.ubuntu.com")
     ]
+
+
+def test_keyrings_path_for_root():
+    assert AptKeyManager.keyrings_path_for_root() == KEYRINGS_PATH
+    assert AptKeyManager.keyrings_path_for_root(Path("/my/root")) == Path(
+        "/my/root/etc/apt/keyrings"
+    )

--- a/tests/unit/repo/test_apt_preferences_manager.py
+++ b/tests/unit/repo/test_apt_preferences_manager.py
@@ -16,10 +16,12 @@
 #
 """Tests for apt_preferencs_manager"""
 import shutil
+from pathlib import Path
 from textwrap import dedent
 
 import pytest
 from craft_archives.repo.apt_preferences_manager import (
+    _DEFAULT_PREFERENCES_FILE,
     AptPreferencesManager,
     Preference,
 )
@@ -232,6 +234,15 @@ def test_preferences_added(test_data_dir, tmp_path, preferences, expected_file):
     manager.write()
 
     assert actual_path.read_text() == expected_path.read_text()
+
+
+def test_preferences_path_for_root():
+    assert (
+        AptPreferencesManager.preferences_path_for_root() == _DEFAULT_PREFERENCES_FILE
+    )
+    assert AptPreferencesManager.preferences_path_for_root(Path("/my/root")) == Path(
+        "/my/root/etc/apt/preferences.d/craft-archives"
+    )
 
 
 # endregion


### PR DESCRIPTION
This commit adds a new public function, "install_in_root()", that installs package repositories in a location that contains an Apt-based system, and _not_ the host system. The intention is that eventually said system will be chroot'ed into, at which point an "apt update" will pick up the new repositories.

The motivation is to support package repositories in overlays in Rockcraft.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
