### PR TITLE
docs: changelog for 1.1.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 See the `Releases page`_ on Github for a complete list of commits that are
 included in each version.
 
+1.1.0 (2023-05-30)
+------------------
+
+- Add support for configuring Apt repositories in non-default roots
+
 1.0.0 (2023-05-24)
 ------------------
 


### PR DESCRIPTION
The only change is the support for non-default roots, which is needed to install package repositories in overlays in Rockcraft.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
