### PR TITLE
keys: make AptKeyManager.install_key() more robust

### DIFF
--- a/craft_archives/repo/apt_key_manager.py
+++ b/craft_archives/repo/apt_key_manager.py
@@ -220,6 +220,11 @@ class AptKeyManager:
         if not fingerprints:
             raise errors.AptGPGKeyInstallError("Invalid GPG key", key=key)
 
+        if key_id and key_id not in fingerprints:
+            raise errors.AptGPGKeyInstallError(
+                "Desired key_id not found in fingerprints", key=key
+            )
+
         self._create_keyrings_path()
         target_id = key_id or fingerprints[0]
         keyring_path = get_keyring_path(target_id, base_path=self._keyrings_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,8 @@ ignore = [
     "D213",  # Multi-line docstring summary should start at the second line (reason: pep257 default)
     "D215",  # Section underline is over-indented (reason: pep257 default)
     "A003",  # Class attribute shadowing built-in (reason: Class attributes don't often get bare references)
-
+    "UP006", # Use `list` instead of `List` for type annotation
+    "UP007", # Use `X | Y` for type annotations
 ]
 
 [tool.ruff.per-file-ignores]

--- a/tests/unit/repo/test_apt_key_manager.py
+++ b/tests/unit/repo/test_apt_key_manager.py
@@ -256,13 +256,18 @@ def test_is_key_installed_with_gpg_failure(
     mock_logger.warning.assert_called_once_with("gpg error: some error")
 
 
+@pytest.mark.parametrize("key_id", (None, "FAKE-KEY-ID-FROM-GNUPG"))
 def test_install_key(
-    apt_gpg, mock_run, mock_chmod, sample_key_string, sample_key_bytes
+    apt_gpg, mock_run, mock_chmod, sample_key_string, sample_key_bytes, tmp_path, key_id
 ):
     mock_run.return_value.stdout = SAMPLE_GPG_SHOW_KEY_OUTPUT
     mock_run.return_value.stderr = None
 
     apt_gpg.install_key(key=sample_key_string)
+
+    # The key should be imported to a file that contains the short-id of the
+    # "FAKE-KEY-ID-FROM-GNUPG" fingerprint, (so the last 8 characters).
+    expected_imported_keyring = f"gnupg-ring:{tmp_path / 'craft-OM-GNUPG.gpg'}"
 
     assert mock_run.mock_calls == [
         call(
@@ -289,7 +294,7 @@ def test_install_key(
                 "--no-default-keyring",
                 "--with-colons",
                 "--keyring",
-                mock.ANY,
+                expected_imported_keyring,
                 "--homedir",
                 mock.ANY,
                 "--import",
@@ -347,20 +352,28 @@ def test_install_key_with_gpg_failure(apt_gpg, mock_run):
     assert str(raised.value) == "Failed to install GPG key: some error"
 
 
-@pytest.mark.parametrize(
-    "fingerprints,error",
-    [
-        pytest.param([], "Invalid GPG key", id="no keys"),
-    ],
-)
-def test_install_key_with_key_issue(apt_gpg, mocker, fingerprints, error):
+def test_install_key_with_no_fingerprints(apt_gpg, mocker):
+    """Test installing key contents that have no fingerprints at all."""
     mock_fingerprints = mocker.patch.object(apt_gpg, "get_key_fingerprints")
-    mock_fingerprints.return_value = fingerprints
+    mock_fingerprints.return_value = []
 
     with pytest.raises(errors.AptGPGKeyInstallError) as raised:
         apt_gpg.install_key(key="key")
 
-    assert str(raised.value) == f"Failed to install GPG key: {error}"
+    assert str(raised.value) == "Failed to install GPG key: Invalid GPG key"
+
+
+def test_install_key_with_invalid_key_id(apt_gpg, mocker):
+    """Test installing key contents where the desired key-id is *not* among the
+    existing fingerprints."""
+    mock_fingerprints = mocker.patch.object(apt_gpg, "get_key_fingerprints")
+    mock_fingerprints.return_value = ["FINGERPRINT-1", "FINGERPRINT-2"]
+
+    expected_error = (
+        "Failed to install GPG key: Desired key_id not found in fingerprints"
+    )
+    with pytest.raises(errors.AptGPGKeyInstallError, match=expected_error):
+        apt_gpg.install_key(key="key", key_id="IM-NOT-THERE")
 
 
 def test_install_key_from_keyserver(apt_gpg, mock_run, mock_chmod):


### PR DESCRIPTION
This commit relaxes the restriction of the provided key contents having only a single (primary) key, and makes AptKeyManager better handle the fact that "gpg import" might print out useful diagnostics messages even if the key contents are imported "successfully".

To do this, we capture gpg's output and add a new optional parameter for the desired "target" key fingerprint (the key that we desire to import even if other keys exist in the contents). This fingerprint is used when naming the imported file, and then:

1) If we don't have a desired fingerprint, proceed as before. 2) If we have a desired fingerprint, check for it in the imported file,
  failing if it's not there.

The motivation for this change is that there are keys "in the wild" that generate gpg error messages but still contain a valid, non-expired desired key. This was supported before but regressed when we moved away from apt-key.

This commit is the second one on the road to fixing the "multiple keys in the same file" regression.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
