### PR TITLE
fix: handle existing ubuntu deb822 sources

### DIFF
--- a/craft_archives/repo/apt_sources_manager.py
+++ b/craft_archives/repo/apt_sources_manager.py
@@ -202,7 +202,7 @@ class AptSourcesManager:
         url = str(package_repo.url)
 
         logger.debug(
-            "Looking for existing sources files for url %s and suites %s", url, suites
+            "Looking for existing sources files for url '%s' and suites %s", url, suites
         )
         # Check whether this url is already listed in an existing sources file
         existing_key = _get_existing_keyring_for(

--- a/craft_archives/repo/errors.py
+++ b/craft_archives/repo/errors.py
@@ -142,3 +142,25 @@ class AptGPGKeyInstallError(PackageRepositoryError):
             details=details,
             resolution="Verify any configured GPG keys",
         )
+
+
+class SourcesKeyConflictError(PackageRepositoryError):
+    """A requested key-id conflicts with existing sources' keys."""
+
+    def __init__(
+        self,
+        *,
+        requested_key_id: str,
+        requested_url: str,
+        conflict_keyring: str,
+        conflicting_source: pathlib.Path,
+    ) -> None:
+        message = (
+            f"The key {requested_key_id!r} for the repository with url "
+            f"{requested_url!r} conflicts with a source in '{conflicting_source}', "
+            f"which is signed by {conflict_keyring!r}."
+        )
+
+        super().__init__(
+            message, resolution="Check the key-id of requested repositories."
+        )

--- a/craft_archives/repo/gpg.py
+++ b/craft_archives/repo/gpg.py
@@ -1,0 +1,83 @@
+# This file is part of craft-archives.
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Utilities to interact with gpg."""
+
+import logging
+import pathlib
+import subprocess
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+# GnuPG command line options that we always want to use.
+_GPG_PREFIX = ["gpg", "--batch", "--no-default-keyring", "--with-colons"]
+
+
+def is_key_in_keyring(key_id: str, keyring_file: pathlib.Path) -> bool:
+    """Whether the ``keyring_file`` keyring contains the ``key_id`` key."""
+    try:
+        logger.debug("Listing keys in keyring...")
+        call_gpg("--list-keys", key_id, keyring=keyring_file)
+    except subprocess.CalledProcessError as error:
+        logger.warning(f"gpg error: {error.output.decode()}")
+        return False
+    else:
+        return True
+
+
+def call_gpg(
+    *parameters: str,
+    keyring: pathlib.Path | None = None,
+    base_parameters: Iterable[str] = _GPG_PREFIX,
+    stdin: bytes | None = None,
+    log: bool = False,
+) -> bytes:
+    """Call "gpg" with the appropriate common parameters.
+
+    :return: The process' stdout.
+    """
+    if keyring:
+        command = [*base_parameters, "--keyring", f"gnupg-ring:{keyring}", *parameters]
+    else:
+        command = [*base_parameters, *parameters]
+    logger.debug(f"Executing command: {command}")
+    env = {"LANG": "C.UTF-8"}
+    try:
+        process = subprocess.run(
+            command,
+            input=stdin,
+            capture_output=True,
+            check=True,
+            env=env,
+        )
+        if log:
+            _log_gpg(process)
+        return process.stdout
+    except subprocess.CalledProcessError as error:
+        if log:
+            _log_gpg(error)
+        raise
+
+
+def _log_gpg(
+    entity: subprocess.CompletedProcess[bytes] | subprocess.CalledProcessError,
+) -> None:
+    if entity.stdout:
+        logger.debug("gpg stdout:")
+        logger.debug(entity.stdout.decode())
+    if entity.stderr:
+        logger.debug("gpg stderr:")
+        logger.debug(entity.stderr.decode())

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,9 +8,9 @@ included in each version.
 X.Y.Z (YYYY-MMM-DD)
 -------------------
 
-* Fix an issue where declaring a package-repository to an Ubuntu archive (for example,
-  to add an architecture) would cause an error in a later ``apt update`` when
-  in Noble.
+* Fix an issue where declaring a package-repository to an Ubuntu archive (for
+  example, to add an architecture) would cause an error in a later ``apt
+  update`` when in Noble.
 
 2.0.0 (2024-08-08)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@ Changelog
 See the `Releases page`_ on Github for a complete list of commits that are
 included in each version.
 
+X.Y.Z (YYYY-MMM-DD)
+-------------------
+
+* Fix an issue where declaring a package-repository to an Ubuntu archive (e.g.
+  to add an architecture) would cause an error in a later ``apt update`` when
+  in Noble.
+
 2.0.0 (2024-08-08)
 ------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ included in each version.
 X.Y.Z (YYYY-MMM-DD)
 -------------------
 
-* Fix an issue where declaring a package-repository to an Ubuntu archive (e.g.
+* Fix an issue where declaring a package-repository to an Ubuntu archive (for example,
   to add an architecture) would cause an error in a later ``apt update`` when
   in Noble.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "lazr.uri",
     "overrides",
     "pydantic>=2.0.0,<3.0.0",
+    "python-debian==0.1.49",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tests/integration/repo/test_apt_sources_manager.py
+++ b/tests/integration/repo/test_apt_sources_manager.py
@@ -1,0 +1,92 @@
+# This file is part of craft-archives.
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration tests for AptSourcesManager."""
+
+import logging
+import textwrap
+
+from craft_archives.repo import gpg
+from craft_archives.repo.apt_sources_manager import AptSourcesManager
+from craft_archives.repo.package_repository import PackageRepositoryApt
+from debian import deb822
+
+# pyright: reportGeneralTypeIssues=false
+
+EXPECTED_SIGNED_BY = "/usr/share/keyrings/FC42E99D.gpg"
+
+DEFAULT_SOURCE = f"""
+Types: deb
+URIs: http://archive.ubuntu.com/ubuntu/
+Suites: noble noble-updates noble-backports
+Components: main universe restricted multiverse
+Architectures: i386
+Signed-By: {EXPECTED_SIGNED_BY}
+"""
+
+
+def test_install_sources_conflicting_keys(tmp_path, test_data_dir, caplog):
+    caplog.set_level(logging.DEBUG)
+    fake_system = tmp_path
+
+    # Set up a base system that already has the repository that we want to
+    # configure, signed by a key that exists on the system.
+    keys_dir = fake_system / "usr/share/keyrings/"
+    keys_dir.mkdir(parents=True)
+    gpg.call_gpg(
+        "-o",
+        str(keys_dir / "FC42E99D.gpg"),
+        "--dearmor",
+        str(test_data_dir / "FC42E99D.asc"),
+    )
+
+    sources_dir = fake_system / "etc/apt/sources.list.d/"
+    sources_dir.mkdir(parents=True)
+    ubuntu_sources = sources_dir / "ubuntu.sources"
+
+    ubuntu_sources.write_text(DEFAULT_SOURCE)
+
+    repository = PackageRepositoryApt(
+        type="apt",
+        # Note that the `url` string is different from the URIs in DEFAULT_SOURCE,
+        # but they mean the same URL.
+        url="http://archive.ubuntu.com/ubuntu",
+        suites=["noble"],
+        components=["main", "universe"],
+        architectures=["i386"],
+        key_id="78E1918602959B9C59103100F1831DDAFC42E99D",
+    )
+    sources_manager = AptSourcesManager(
+        sources_list_d=sources_dir, signed_by_root=fake_system
+    )
+    sources_manager._install_sources_apt(package_repo=repository)
+
+    craft_source = sources_dir / "craft-http_archive_ubuntu_com_ubuntu.sources"
+    assert craft_source.is_file()
+
+    craft_dict = deb822.Deb822(sequence=craft_source.read_text())
+    assert craft_dict["Signed-By"] == EXPECTED_SIGNED_BY
+
+    expected_log = textwrap.dedent(
+        f"""
+        Looking for existing sources files for url http://archive.ubuntu.com/ubuntu and suites ['noble']
+        Reading sources in '{ubuntu_sources}' looking for 'http://archive.ubuntu.com/ubuntu/'
+        Source has these suites: ['noble', 'noble-backports', 'noble-updates']
+        Suites match - Signed-By is '/usr/share/keyrings/FC42E99D.gpg'
+        """
+    ).strip()
+
+    all_log = "\n".join(caplog.messages)
+    assert expected_log in all_log

--- a/tests/unit/repo/test_apt_key_manager.py
+++ b/tests/unit/repo/test_apt_key_manager.py
@@ -100,9 +100,7 @@ def mock_apt_uca_key_id(mocker):
 
 @pytest.fixture()
 def mock_logger(mocker):
-    yield mocker.patch(
-        "craft_archives.repo.apt_key_manager.logger", spec=logging.Logger
-    )
+    yield mocker.patch("craft_archives.repo.gpg.logger", spec=logging.Logger)
 
 
 @pytest.fixture


### PR DESCRIPTION
The problem is this: since Noble, the default Ubuntu archives are listed as deb822 sources in `/etc/apt/sources.lists.d/ubuntu.sources` as signed by a key in `/usr/share/keyrings`. Trying to declare a package-repository with the url of an official archive (e.g. to add an architecture) would then fail because apt complained that a given suite under archive.ubuntu.com/ubuntu was being declared as Signed-By two keyrings (the official one and the craft-added one).

This commit updates the handling of sources for the specific case of those sources that are also declared in `ubuntu.sources`:
- IF a package-repository has an url that matches an official repo,
- AND IF this repo is already declared in a deb822-format sources file,
- AND IF the requested key-id is present in the existing sources' declared keyring,

... then the new sources file will point to the existing keyring, instead of the usual CRAFT-xxx keyring. This commit updates a lot of code, but most of of it is moving existing code around, and the new code specifically only applies to the `ubuntu.sources` file. This is to minimize the blast-radius of this change and allow this to be a 'fix' rather than a 'feat'.

Fixes #129

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
