### PR TITLE
fix: disregard scheme when looking for existing sources

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@ Changelog
 See the `Releases page`_ on Github for a complete list of commits that are
 included in each version.
 
+2.0.2 (2024-Dec-04)
+-------------------
+
+* Fix an issue where declaring a package-repository to an Ubuntu archive
+  using the "https" scheme would cause an error in a later ``apt update``
+  when in Noble.
+
 2.0.1 (2024-Oct-21)
 -------------------
 

--- a/tests/integration/repo/test_apt_sources_manager.py
+++ b/tests/integration/repo/test_apt_sources_manager.py
@@ -41,43 +41,49 @@ Signed-By: {source_key}
     ["source_url", "repo_url", "repo_arch", "expected_url"],
     [
         # Exact same url
-        (
+        pytest.param(
             "http://archive.ubuntu.com/ubuntu/",
             "http://archive.ubuntu.com/ubuntu/",
             "i386",
             "archive.ubuntu.com/ubuntu/",
+            id="archive-same-url",
         ),
-        (
+        pytest.param(
             "http://ports.ubuntu.com/ubuntu-ports/",
             "http://ports.ubuntu.com/ubuntu-ports/",
             "armhf",
             "ports.ubuntu.com/ubuntu-ports/",
+            id="ports-same-url",
         ),
         # Different url (no ending /)
-        (
+        pytest.param(
             "http://archive.ubuntu.com/ubuntu/",
             "http://archive.ubuntu.com/ubuntu",
             "i386",
             "archive.ubuntu.com/ubuntu/",
+            id="archive-different-ending",
         ),
-        (
+        pytest.param(
             "http://ports.ubuntu.com/ubuntu-ports/",
             "http://ports.ubuntu.com/ubuntu-ports",
             "armhf",
             "ports.ubuntu.com/ubuntu-ports/",
+            id="ports-different-ending",
         ),
         # Different scheme (http vs https)
-        (
+        pytest.param(
             "http://archive.ubuntu.com/ubuntu/",
             "https://archive.ubuntu.com/ubuntu",
             "i386",
             "archive.ubuntu.com/ubuntu/",
+            id="archive-different-scheme",
         ),
-        (
+        pytest.param(
             "http://ports.ubuntu.com/ubuntu-ports/",
             "https://ports.ubuntu.com/ubuntu-ports",
             "armhf",
             "ports.ubuntu.com/ubuntu-ports/",
+            id="ports-different-scheme",
         ),
     ],
 )

--- a/tests/integration/repo/test_apt_sources_manager.py
+++ b/tests/integration/repo/test_apt_sources_manager.py
@@ -38,14 +38,51 @@ Signed-By: {source_key}
 
 
 @pytest.mark.parametrize(
-    ["source_url", "source_arch"],
+    ["source_url", "repo_url", "repo_arch", "expected_url"],
     [
-        ("http://archive.ubuntu.com/ubuntu/", "i386"),
-        ("http://ports.ubuntu.com/ubuntu-ports/", "armhf"),
+        # Exact same url
+        (
+            "http://archive.ubuntu.com/ubuntu/",
+            "http://archive.ubuntu.com/ubuntu/",
+            "i386",
+            "archive.ubuntu.com/ubuntu/",
+        ),
+        (
+            "http://ports.ubuntu.com/ubuntu-ports/",
+            "http://ports.ubuntu.com/ubuntu-ports/",
+            "armhf",
+            "ports.ubuntu.com/ubuntu-ports/",
+        ),
+        # Different url (no ending /)
+        (
+            "http://archive.ubuntu.com/ubuntu/",
+            "http://archive.ubuntu.com/ubuntu",
+            "i386",
+            "archive.ubuntu.com/ubuntu/",
+        ),
+        (
+            "http://ports.ubuntu.com/ubuntu-ports/",
+            "http://ports.ubuntu.com/ubuntu-ports",
+            "armhf",
+            "ports.ubuntu.com/ubuntu-ports/",
+        ),
+        # Different scheme (http vs https)
+        (
+            "http://archive.ubuntu.com/ubuntu/",
+            "https://archive.ubuntu.com/ubuntu",
+            "i386",
+            "archive.ubuntu.com/ubuntu/",
+        ),
+        (
+            "http://ports.ubuntu.com/ubuntu-ports/",
+            "https://ports.ubuntu.com/ubuntu-ports",
+            "armhf",
+            "ports.ubuntu.com/ubuntu-ports/",
+        ),
     ],
 )
 def test_install_sources_conflicting_keys(
-    tmp_path, test_data_dir, caplog, source_url, source_arch
+    tmp_path, test_data_dir, caplog, source_url, repo_url, repo_arch, expected_url
 ):
     caplog.set_level(logging.DEBUG)
     fake_system = tmp_path
@@ -72,15 +109,12 @@ def test_install_sources_conflicting_keys(
         )
     )
 
-    # Note that the `url` string is different from the URIs in DEFAULT_SOURCE,
-    # but they mean the same URL.
-    repo_url = source_url[:-1]
     repository = PackageRepositoryApt(
         type="apt",
         url=repo_url,
         suites=["noble"],
         components=["main", "universe"],
-        architectures=[source_arch],
+        architectures=[repo_arch],
         key_id="78E1918602959B9C59103100F1831DDAFC42E99D",
     )
     sources_manager = AptSourcesManager(
@@ -96,8 +130,8 @@ def test_install_sources_conflicting_keys(
 
     expected_log = textwrap.dedent(
         f"""
-        Looking for existing sources files for url '{repo_url}' and suites ['noble']
-        Reading sources in '{ubuntu_sources}' looking for '{source_url}'
+        Looking for existing sources files for url '{repository.url}' and suites ['noble']
+        Reading sources in '{ubuntu_sources}' looking for '{expected_url}'
         Source has these suites: ['noble', 'noble-backports', 'noble-updates']
         Suites match - Signed-By is '/usr/share/keyrings/FC42E99D.gpg'
         """

--- a/tests/unit/repo/test_apt_sources_manager.py
+++ b/tests/unit/repo/test_apt_sources_manager.py
@@ -440,7 +440,7 @@ def test_existing_key_incompatible(apt_sources_mgr, tmp_path, mocker):
 
     expected_message = re.escape(
         "The key '78E1918602959B9C59103100F1831DDAFC42E99D' for "
-        "the repository with url 'http://archive.ubuntu.com/ubuntu/' conflicts "
+        "the repository with url 'http://archive.ubuntu.com/ubuntu' conflicts "
         f"with a source in '{ubuntu_sources}', "
         "which is signed by '/usr/share/keyrings/0264B26D.gpg'"
     )


### PR DESCRIPTION
Apt does not take the scheme (e.g. http vs https) into account when parsing sources, which means that, for the purposes of finding existing keys, 'https://archive.ubuntu.com' and 'http://archive.ubuntu.com' should be considered the same.

Fixes #139

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
