### PR TITLE
docs: use rtd config from starbase

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,20 +7,26 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: dirhtml
   configuration: docs/conf.py
 
 # Optionally build your docs in additional formats such as PDF
-formats:
-  - pdf
+# formats:
+#  - pdf
+#  - epub
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+    python: "3.12"
+  jobs:
+    post_checkout:
+      - git fetch --tags --unshallow # Also fetch tags
+    post_system_dependencies:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --extra docs


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

When starbasing in #143, the RTD config wasn't updated, causing docs builds to fail. This PR just brings in that config