### PR TITLE
ci: switch to public runners

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -16,6 +16,6 @@ jobs:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
       # Testing on both amd64 and arm64 to prevent architecture-specific bugs.
-      fast-test-platforms: '["jammy", ["noble", "amd64"], ["noble", "arm64"]]'
-      slow-test-platforms: '[["jammy", "amd64"], ["jammy", "arm64"]]'
-      lowest-python-platform: jammy
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"]'
+      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+      lowest-python-platform: ubuntu-22.04


### PR DESCRIPTION
Switch to using the public CI runners to reduce resource contention.

Config change is PR'd at https://github.com/canonical/canonical-repo-automation/pull/285

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---
