### PR TITLE
build: clean up dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,11 @@ license = "LGPL-3.0-or-later"
 
 [dependency-groups]
 lint = [
+    { include-group = "types" },
     "codespell[toml]~=2.3",
 ]
 types = [
     "mypy[reports]~=1.5",
-    "pyright==1.1.406",
 ]
 docs = [
     "canonical-sphinx[full]~=0.4",

--- a/uv.lock
+++ b/uv.lock
@@ -458,6 +458,7 @@ docs = [
 ]
 lint = [
     { name = "codespell", extra = ["toml"] },
+    { name = "mypy", extra = ["reports"] },
 ]
 tics = [
     { name = "flake8" },
@@ -465,7 +466,6 @@ tics = [
 ]
 types = [
     { name = "mypy", extra = ["reports"] },
-    { name = "pyright" },
 ]
 
 [package.metadata]
@@ -496,15 +496,15 @@ docs = [
     { name = "sphinx-toolbox", specifier = "~=4.0" },
     { name = "sphinxext-rediraffe", specifier = "==0.3.0" },
 ]
-lint = [{ name = "codespell", extras = ["toml"], specifier = "~=2.3" }]
+lint = [
+    { name = "codespell", extras = ["toml"], specifier = "~=2.3" },
+    { name = "mypy", extras = ["reports"], specifier = "~=1.5" },
+]
 tics = [
     { name = "flake8" },
     { name = "pylint" },
 ]
-types = [
-    { name = "mypy", extras = ["reports"], specifier = "~=1.5" },
-    { name = "pyright", specifier = "==1.1.406" },
-]
+types = [{ name = "mypy", extras = ["reports"], specifier = "~=1.5" }]
 
 [[package]]
 name = "cssutils"
@@ -1120,15 +1120,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
-]
-
-[[package]]
 name = "oauthlib"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1346,19 +1337,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/22/f1129e69d94ffff626bdb5c835506b3a5b4f3d070f17ea295e12c2c6f60f/pyparsing-3.2.3.tar.gz", hash = "sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be", size = 1088608, upload-time = "2025-03-25T05:01:28.114Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl", hash = "sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf", size = 111120, upload-time = "2025-03-25T05:01:24.908Z" },
-]
-
-[[package]]
-name = "pyright"
-version = "1.1.406"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/16/6b4fbdd1fef59a0292cbb99f790b44983e390321eccbc5921b4d161da5d1/pyright-1.1.406.tar.gz", hash = "sha256:c4872bc58c9643dac09e8a2e74d472c62036910b3bd37a32813989ef7576ea2c", size = 4113151, upload-time = "2025-10-02T01:04:45.488Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/a2/e309afbb459f50507103793aaef85ca4348b66814c86bc73908bdeb66d12/pyright-1.1.406-py3-none-any.whl", hash = "sha256:1d81fb43c2407bf566e97e57abb01c811973fdb21b2df8df59f870f688bdca71", size = 5980982, upload-time = "2025-10-02T01:04:43.137Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

- Removes pyright from the package dependencies, as this is installed already in the Makefile
- Includes the `types` group in the `lint` group as the latter is always going to want the former.