### PR TITLE
fix: try proxy settings with another gpg error

### DIFF
--- a/craft_archives/repo/apt_key_manager.py
+++ b/craft_archives/repo/apt_key_manager.py
@@ -339,7 +339,6 @@ def retry_with_fallback_keyserver(
     error: subprocess.CalledProcessError, key_server: str
 ) -> bool:
     """Check if the gpg error should be retried using the fallback default keyserver."""
-    return (
-        errors.GPG_TIMEOUT_MESSAGE in error.stderr.decode()
-        and key_server == DEFAULT_APT_KEYSERVER
+    return key_server == DEFAULT_APT_KEYSERVER and any(
+        message in error.stderr.decode() for message in errors.GPG_PROXY_ERRORS
     )

--- a/craft_archives/repo/errors.py
+++ b/craft_archives/repo/errors.py
@@ -92,6 +92,10 @@ class AptGPGKeyringError(PackageRepositoryError):
 
 
 GPG_TIMEOUT_MESSAGE = "gpg: keyserver receive failed: Connection timed out"
+GPG_NETWORK_UNREACHABLE = "gpg: keyserver receive failed: Network is unreachable"
+
+# Errors that are possibly caused by a proxy server not being used.
+GPG_PROXY_ERRORS = (GPG_TIMEOUT_MESSAGE, GPG_NETWORK_UNREACHABLE)
 
 
 class AptGPGKeyInstallError(PackageRepositoryError):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@ Changelog
 See the `Releases page`_ on Github for a complete list of commits that are
 included in each version.
 
+2.2.1 (2026-07-08)
+------------------
+
+Bug Fixes
+
+* Retry with the system's HTTP proxy settings on more gpg failure scenarios.
+
 2.2.0 (2025-08-13)
 ------------------
 

--- a/tests/unit/repo/test_apt_key_manager.py
+++ b/tests/unit/repo/test_apt_key_manager.py
@@ -421,16 +421,14 @@ def test_install_key_from_keyserver_with_gpg_failure(apt_gpg, mock_run):
     assert str(raised.value) == "Failed to install GPG key: some error"
 
 
-def test_install_key_from_keyserver_with_gpg_timeout(
-    apt_gpg,
-    monkeypatch,
-    mock_run,
-    mock_chmod,
+@pytest.mark.parametrize("error_message", errors.GPG_PROXY_ERRORS)
+def test_install_key_from_keyserver_with_gpg_errors(
+    apt_gpg, monkeypatch, mock_run, mock_chmod, error_message
 ):
     monkeypatch.setenv("http_proxy", "http://a-proxy-url:3128")
     mock_run.side_effect = [
         subprocess.CalledProcessError(
-            cmd=["gpg"], returncode=1, stderr=errors.GPG_TIMEOUT_MESSAGE.encode()
+            cmd=["gpg"], returncode=1, stderr=error_message.encode()
         ),
         subprocess.CompletedProcess(
             ["gpg"], returncode=0, stdout=SAMPLE_GPG_SHOW_KEY_OUTPUT


### PR DESCRIPTION
In some environments it's possible that gpg says that the network is unreachable, rather than that the connection timed out, when a proxy needs to be used.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
